### PR TITLE
fix: create automated ghes-compatible release

### DIFF
--- a/.github/workflows/create-ghes-release.yml
+++ b/.github/workflows/create-ghes-release.yml
@@ -1,0 +1,80 @@
+name: Create GHES Compatible Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build-ghes-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: 🔧 Get version from tag
+        id: get_version
+        run: |
+          echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: 🌳 Create GHES release branch
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b release/v${{ steps.get_version.outputs.version }}-ghes
+
+      - name: 🔄 Downgrade actions for GHES
+        id: downgrade
+        run: |
+          set -euo pipefail
+          echo "Downgrading actions in action.yml files for GHES compatibility..."
+          
+          files_to_change=$(find . -type f -name "action.yml")
+          
+          if [ -z "$files_to_change" ]; then
+            echo "::error::No action.yml files found to process."
+            exit 1
+          fi
+          
+          # Find all action.yml files and downgrade upload-artifact from v4 to v3
+          echo "$files_to_change" | xargs sed -i 's|actions/upload-artifact@v4|actions/upload-artifact@v3|g'
+          
+          echo "✅ Actions downgraded successfully."
+
+      - name: ⬆️ Commit and push changes
+        run: |
+          # Check if there are changes to commit
+          if git diff --quiet; then
+            echo "No changes to commit. Skipping commit and push."
+          else
+            git commit -am "chore: downgrade actions for GHES compatibility"
+            git push -u origin release/v${{ steps.get_version.outputs.version }}-ghes
+          fi
+
+      - name: 🎉 Create GHES Release
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.get_version.outputs.version }}"
+          GHES_TAG="v${VERSION}-ghes"
+          RELEASE_BRANCH="release/${GHES_TAG}"
+          
+          # Get release notes from the original release, with a fallback for an empty body
+          RELEASE_NOTES=$(gh release view "${{ github.event.release.tag_name }}" --json body --jq .body) || RELEASE_NOTES="See original release for details."
+          
+          gh release create "$GHES_TAG" \
+            --target "$RELEASE_BRANCH" \
+            --title "v${VERSION} (GHES)" \
+            --notes "$RELEASE_NOTES"
+
+      - name: 🧹 Cleanup release branch
+        if: always()
+        run: |
+          git push origin --delete release/v${{ steps.get_version.outputs.version }}-ghes


### PR DESCRIPTION
# Pull Request

## Checklist

- [x] My pull request addresses a single issue or concern
- [x] I have described the changes clearly
- [x] I have run all pre-commit checks (`pre-commit run --all-files`)
- [x] I have updated documentation as needed (e.g., `README.md`)
- [x] I have tested the changes (if applicable)
- [x] I have checked for breaking changes

## Description

This PR introduces a new, fully automated GitHub Actions workflow to provide compatibility for GitHub Enterprise Server (GHES) users.

1. Triggers when a new release is published.
2. Creates a corresponding release with a `-ghes` suffix (e.g., `v1.2.3-ghes`).
3. In this new release, it downgrades `actions/upload-artifact` to the GHES-compatible `v3`.

## Related Issues

Closes #12
