### PR TITLE
fix: resolve plan file path relative to working_directory in apply

### DIFF
--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -199,7 +199,23 @@ class TerraformExecutor:
         )
         if resolved_plan and resolved_plan.exists():
             args.append(str(plan_file))
+        elif plan_file is not None:
+            # A plan file was explicitly requested but not found — abort.
+            # Never silently fall through to an untargeted apply.
+            msg = (
+                f"Plan file '{plan_file}' not found "
+                f"(resolved: '{resolved_plan}'). "
+                "Refusing to run untargeted apply."
+            )
+            console.print(f"[red]❌ {msg}[/red]")
+            return ApplyResult(
+                exit_code=1,
+                stdout="",
+                stderr=msg,
+                command=["terraform", "apply", "(aborted)"],
+            )
         else:
+            # No plan file requested (e.g. rollback) — apply with var-files
             for var_file in self.var_files:
                 args.extend(["-var-file", var_file])
             args.extend(self.apply_args)

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -189,7 +189,15 @@ class TerraformExecutor:
 
         args = ["terraform", "apply", TF_INPUT_FALSE, "-auto-approve"]
 
-        if plan_file and plan_file.exists():
+        # Resolve plan_file relative to working_directory since subprocess
+        # runs with cwd=working_directory but Path.exists() checks from
+        # the Python process CWD (which may be different).
+        resolved_plan = (
+            (self.working_directory / plan_file)
+            if plan_file and not plan_file.is_absolute()
+            else plan_file
+        )
+        if resolved_plan and resolved_plan.exists():
             args.append(str(plan_file))
         else:
             for var_file in self.var_files:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -182,6 +182,44 @@ class TestTerraformExecutor:
         # Var files should NOT be in command when using plan file
         assert "-var-file" not in args
 
+    @patch("subprocess.run")
+    def test_apply_with_relative_plan_file_in_working_directory(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """apply() resolves relative plan file path against working_directory.
+
+        Regression test: when _apply_with_plan passes Path(plan_file.name)
+        (a bare filename), the executor must resolve it relative to
+        working_directory — not the Python process CWD — to find the file.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        # Simulate: working_directory = tmp_path/terraform/modules
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        # Plan file exists inside working_directory
+        plan_file = working_dir / "tfplan-int-06b61570.tfplan"
+        plan_file.write_bytes(b"targeted plan content")
+
+        executor = TerraformExecutor(
+            working_directory=working_dir,
+            var_files=["../config/int/int_config.tfvars"],
+        )
+
+        # Pass only the bare filename (as _apply_with_plan does)
+        executor.apply(plan_file=Path(plan_file.name))
+
+        call_args = mock_run.call_args
+        args = call_args[0][0]
+
+        # Plan file must be in the command — NOT var-file fallback
+        assert plan_file.name in " ".join(args)
+        assert "-var-file" not in args, (
+            "var-file should NOT appear when a plan file exists — "
+            "this means the plan file was not found and a full untargeted apply ran instead"
+        )
+
 
 class TestTfcmtIntegration:
     """Tests for tfcmt integration."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -214,11 +214,37 @@ class TestTerraformExecutor:
         args = call_args[0][0]
 
         # Plan file must be in the command — NOT var-file fallback
-        assert plan_file.name in " ".join(args)
+        assert plan_file.name in args
         assert "-var-file" not in args, (
             "var-file should NOT appear when a plan file exists — "
             "this means the plan file was not found and a full untargeted apply ran instead"
         )
+
+    @patch("subprocess.run")
+    def test_apply_aborts_when_plan_file_provided_but_missing(
+        self, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """apply() aborts when plan_file is provided but does not exist.
+
+        Regression test: a missing plan file must NEVER silently fall through
+        to an untargeted 'terraform apply -auto-approve'. The executor must
+        abort and return a failure exit code.
+        """
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        executor = TerraformExecutor(
+            working_directory=working_dir,
+            var_files=["../config/int/int_config.tfvars"],
+        )
+
+        # Pass a plan file that does NOT exist
+        result = executor.apply(plan_file=Path("tfplan-int-missing.tfplan"))
+
+        assert result.exit_code == 1
+        assert "not found" in result.stderr.lower()
+        # subprocess.run must NOT have been called — no terraform command ran
+        mock_run.assert_not_called()
 
 
 class TestTfcmtIntegration:


### PR DESCRIPTION
## Bug

When `executor.apply()` receives a plan file (bare filename like `tfplan-int-06b61570.tfplan`), it checks `plan_file.exists()` relative to the **Python process CWD** — typically the repository root. However, the plan file physically resides in `self.working_directory` (e.g., `terraform/modules/`).

When these directories differ, the exists check silently fails and the executor falls through to a **full untargeted `terraform apply -auto-approve`** — completely ignoring the saved targeted plan.

### Call chain

1. `_handle_apply()` in `cli.py` constructs the full path and verifies the cached plan exists ✅
2. `_apply_with_plan()` in `cli.py` passes `Path(plan_file.name)` (bare filename) to the executor
3. `executor.apply()` checks `plan_file.exists()` from Python CWD → **False** (wrong directory)
4. Falls through to untargeted apply with `-auto-approve` ❌

### Real-world impact

This bug caused infrastructure damage on a production-like environment:

- A targeted plan (`-target=module.base`) was correctly created and cached
- The subsequent `.apply` command restored the plan file from cache ✅
- But the executor ran `terraform apply -input=false -auto-approve -var-file ...` (no plan file!)
- Terraform destroyed Route53 DNS records and ACM certificate validation records that were outside the target scope
- CloudTrail confirmed the deletions happened during the apply at `2026-04-27T12:32:39 UTC`

### Evidence from CI logs

**Plan run** (correct):
```
terraform plan -input=false -var-file=../config/int/int_config.tfvars -target=module.base -out tfplan-int-06b61570.tfplan
```

**Apply run** (broken — no plan file):
```
✅ Found plan file: terraform/modules/tfplan-int-06b61570.tfplan
...
terraform apply -input=false -auto-approve -var-file=../config/int/int_config.tfvars
```

Note: the cache restoration found the plan file, but the executor discarded it.

## Fix

Resolve `plan_file` against `self.working_directory` before the `exists()` check:

```python
resolved_plan = (
    (self.working_directory / plan_file)
    if plan_file and not plan_file.is_absolute()
    else plan_file
)
if resolved_plan and resolved_plan.exists():
    args.append(str(plan_file))  # pass original relative name to terraform subprocess
```

The subprocess already runs with `cwd=self.working_directory`, so we still pass the original relative filename — we only fix the Python-level existence check.

## Regression test

Added `test_apply_with_relative_plan_file_in_working_directory` that creates a plan file inside the working directory (not CWD) and verifies the executor correctly finds and uses it.

## Additional concern (not addressed in this PR)

The silent fallthrough from "plan file not found" to "full untargeted apply with -auto-approve" is inherently dangerous. If a plan file was explicitly provided but cannot be found, the executor should **abort** rather than proceed with an untargeted apply. This is a separate enhancement worth considering.