### PR TITLE
fix: Rollback & apply safety — priority reorder, full path, blast radius warning

### DIFF
--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -455,12 +455,13 @@ def _handle_apply(
     plan_file = working_dir / plan_filename
     is_rollback = os.environ.get("TF_BD_IS_ROLLBACK", "false").lower() == "true"
 
-    if plan_file.exists():
-        _apply_with_plan(executor, plan_file)
-        console.print(f"[dim]📋 Plan applied: {plan_filename}[/dim]")
-    elif is_rollback:
+    if is_rollback:
         console.print(
             "[yellow]⚡ Rollback detected - applying directly from stable branch[/yellow]"
+        )
+        console.print(
+            "[yellow]⚠️  WARNING: Rollback applies the full stable-branch state without a reviewed plan. "
+            "Ensure the stable branch configuration is correct before proceeding.[/yellow]"
         )
         apply_result = executor.apply()
         if not apply_result.success:
@@ -479,6 +480,9 @@ def _handle_apply(
             set_github_output("failure_reason", error_msg)
             raise typer.Exit(1)
         console.print("[dim]📋 Rollback applied directly (no plan file)[/dim]")
+    elif plan_file.exists():
+        _apply_with_plan(executor, plan_file)
+        console.print(f"[dim]📋 Plan applied: {plan_filename}[/dim]")
     else:
         console.print(f"[red]❌ No plan file found for this SHA: {plan_file}[/red]")
         error_msg = format_error_for_comment(
@@ -517,7 +521,7 @@ def _apply_with_plan(executor: "TerraformExecutor", plan_file: Path) -> None:
             raise typer.Exit(1)
         console.print("[green]✅ Plan checksum verified[/green]")
 
-    apply_result = executor.apply(plan_file=Path(plan_file.name))
+    apply_result = executor.apply(plan_file=plan_file)
     if not apply_result.success:
         logs_url = (
             os.environ.get("GITHUB_SERVER_URL", GITHUB_URL_DEFAULT)

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -189,16 +189,28 @@ class TerraformExecutor:
 
         args = ["terraform", "apply", TF_INPUT_FALSE, "-auto-approve"]
 
-        # Resolve plan_file relative to working_directory since subprocess
-        # runs with cwd=working_directory but Path.exists() checks from
-        # the Python process CWD (which may be different).
-        resolved_plan = (
-            (self.working_directory / plan_file)
-            if plan_file and not plan_file.is_absolute()
-            else plan_file
-        )
+        # Resolve plan_file for existence check. The plan_file may be:
+        # 1. A full path (e.g., /repo/terraform/modules/tfplan-int-abc.tfplan)
+        # 2. A path relative to repo root (e.g., terraform/modules/tfplan-int-abc.tfplan)
+        # 3. A bare filename (e.g., tfplan-int-abc.tfplan) — legacy callers
+        # In all cases, we resolve to an absolute path for the exists() check,
+        # then derive the name relative to working_directory for the terraform command
+        # (since subprocess runs with cwd=working_directory).
+        if plan_file:
+            if plan_file.is_absolute():
+                resolved_plan = plan_file
+            else:
+                resolved_plan = (self.working_directory / plan_file).resolve()
+        else:
+            resolved_plan = None
+
         if resolved_plan and resolved_plan.exists():
-            args.append(str(plan_file))
+            # Pass just the filename to terraform (it runs in working_directory)
+            try:
+                relative_plan = resolved_plan.relative_to(self.working_directory.resolve())
+            except ValueError:
+                relative_plan = resolved_plan
+            args.append(str(relative_plan))
         elif plan_file is not None:
             # A plan file was explicitly requested but not found — abort.
             # Never silently fall through to an untargeted apply.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,3 +313,93 @@ class TestCompleteLifecycleCommand:
             mock_manager.add_reaction.assert_called_with("456", "rocket")
             mock_manager.post_result_comment.assert_called()
             mock_manager.remove_non_sticky_lock.assert_called_with("dev")
+
+
+class TestHandleApply:
+    """Tests for _handle_apply — rollback priority and plan file resolution."""
+
+    def test_rollback_takes_priority_over_stale_plan(self, tmp_path: Path) -> None:
+        """Rollback must execute directly, even if a stale plan file exists.
+
+        Regression: if plan_file.exists() is checked before is_rollback,
+        a stale cached plan could be consumed instead of doing a fresh
+        stable-branch apply.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from tf_branch_deploy.cli import _handle_apply
+
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        # Create a stale plan file that should NOT be used
+        stale_plan = working_dir / "tfplan-int-abc12345.tfplan"
+        stale_plan.write_bytes(b"stale targeted plan")
+
+        mock_executor = MagicMock()
+        mock_executor.apply.return_value = MagicMock(success=True)
+
+        env_vars = {
+            "TF_BD_IS_ROLLBACK": "true",
+        }
+
+        with patch.dict("os.environ", env_vars):
+            _handle_apply(mock_executor, "int", "abc12345ff", working_dir)
+
+        # Executor.apply() must be called with NO plan_file (rollback path)
+        mock_executor.apply.assert_called_once_with()
+
+    def test_plan_file_used_when_not_rollback(self, tmp_path: Path) -> None:
+        """Normal apply uses the cached plan file when it exists."""
+        from unittest.mock import MagicMock, patch
+
+        from tf_branch_deploy.cli import _handle_apply
+
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        # Create the expected plan file
+        plan_file = working_dir / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan")
+
+        mock_executor = MagicMock()
+        mock_executor.apply.return_value = MagicMock(success=True)
+
+        env_vars = {
+            "TF_BD_IS_ROLLBACK": "false",
+        }
+
+        with patch.dict("os.environ", env_vars):
+            _handle_apply(mock_executor, "int", "abc12345ff", working_dir)
+
+        # Executor.apply() must be called WITH plan_file
+        call_args = mock_executor.apply.call_args
+        assert call_args is not None
+        assert "plan_file" in call_args.kwargs or len(call_args.args) > 0
+        plan_arg = call_args.kwargs.get("plan_file", call_args.args[0] if call_args.args else None)
+        assert plan_arg is not None
+        assert "tfplan-int-abc12345.tfplan" in str(plan_arg)
+
+    def test_apply_passes_full_path_to_executor(self, tmp_path: Path) -> None:
+        """_apply_with_plan passes the full resolved path, not a bare filename."""
+        from unittest.mock import MagicMock, patch
+
+        from tf_branch_deploy.cli import _apply_with_plan
+
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        plan_file = working_dir / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan")
+
+        mock_executor = MagicMock()
+        mock_executor.apply.return_value = MagicMock(success=True)
+
+        with patch.dict("os.environ", {}, clear=False):
+            _apply_with_plan(mock_executor, plan_file)
+
+        call_args = mock_executor.apply.call_args
+        plan_arg = call_args.kwargs.get("plan_file")
+        # Must be the full path, not just the bare filename
+        assert plan_arg == plan_file
+        assert str(plan_arg) != plan_file.name

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -178,7 +178,7 @@ class TestTerraformExecutor:
         call_args = mock_run.call_args
         args = call_args[0][0]
 
-        assert str(plan_file) in args
+        assert plan_file.name in args
         # Var files should NOT be in command when using plan file
         assert "-var-file" not in args
 
@@ -245,6 +245,36 @@ class TestTerraformExecutor:
         assert "not found" in result.stderr.lower()
         # subprocess.run must NOT have been called — no terraform command ran
         mock_run.assert_not_called()
+
+    @patch("subprocess.run")
+    def test_apply_with_full_path_plan_file(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        """apply() handles full (absolute) path plan files correctly.
+
+        When cli.py passes the full plan file path instead of a bare filename,
+        the executor resolves it to a relative name for the terraform command.
+        """
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        working_dir = tmp_path / "terraform" / "modules"
+        working_dir.mkdir(parents=True)
+
+        plan_file = working_dir / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan")
+
+        executor = TerraformExecutor(
+            working_directory=working_dir,
+            var_files=["../config/int/int_config.tfvars"],
+        )
+
+        # Pass full path (as _apply_with_plan now does)
+        executor.apply(plan_file=plan_file)
+
+        call_args = mock_run.call_args
+        args = call_args[0][0]
+
+        # The plan filename must appear in the command (relative to working_dir)
+        assert plan_file.name in args
+        assert "-var-file" not in args
 
 
 class TestTfcmtIntegration:


### PR DESCRIPTION
Closes #119

## Summary

Three safety improvements to the apply path:

### 1. Rollback priority (CRITICAL)
`_handle_apply()` now checks `is_rollback` BEFORE `plan_file.exists()`. Previously, a stale cached plan could be consumed during rollback instead of doing a fresh stable-branch apply.

### 2. Full path plan file (HIGH)
`_apply_with_plan()` now passes the full resolved path to the executor instead of `Path(plan_file.name)` (bare filename). The executor resolves absolute paths to relative for the terraform subprocess.

### 3. Blast radius warning (MEDIUM)
Rollback now prints a visible warning that it applies the full stable-branch state without a reviewed plan.

## Tests

- `test_rollback_takes_priority_over_stale_plan`: Verifies rollback executes even when stale plan exists
- `test_plan_file_used_when_not_rollback`: Verifies normal apply uses plan file
- `test_apply_passes_full_path_to_executor`: Verifies full path passed, not bare filename
- `test_apply_with_full_path_plan_file`: Verifies executor handles absolute paths correctly

All 83 tests pass.