### PR TITLE
fix(#120): Command injection protection and log redaction

### DIFF
--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -27,6 +27,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from .config import load_config
+from .executor import _redact_single_arg
 
 DEFAULT_CONFIG_PATH = Path(".tf-branch-deploy.yml")
 GITHUB_URL_DEFAULT = "https://github.com"
@@ -402,7 +403,10 @@ def execute(
     if raw_extra_args:
         parsed_extra_args = _parse_extra_args(raw_extra_args)
         parsed_extra_args = _validate_extra_args(parsed_extra_args)
-        console.print(f"[cyan]📝 Extra args from command:[/cyan] {parsed_extra_args}")
+        console.print(
+            f"[cyan]📝 Extra args from command:[/cyan]"
+            f" {[_redact_single_arg(a) for a in parsed_extra_args]}"
+        )
 
     table = Table(title="Terraform Execution")
     table.add_column("Setting", style="cyan")
@@ -413,7 +417,10 @@ def execute(
     table.add_row("Working Dir", str(resolved_working_dir))
     table.add_row("Dry Run", str(dry_run))
     if parsed_extra_args:
-        table.add_row("Extra Args", " ".join(parsed_extra_args))
+        table.add_row(
+            "Extra Args",
+            " ".join(_redact_single_arg(a) for a in parsed_extra_args),
+        )
     console.print(table)
 
     var_files = config.resolve_var_files(environment)

--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -103,6 +103,61 @@ def format_error_for_comment(
     return "\n".join(lines)
 
 
+ALLOWED_EXTRA_ARG_FLAGS: frozenset[str] = frozenset(
+    {
+        "-target",
+        "-var",
+        "-var-file",
+        "-refresh",
+        "-parallelism",
+        "-compact-warnings",
+        "-lock",
+        "-lock-timeout",
+        "-replace",
+    }
+)
+
+BLOCKED_EXTRA_ARG_FLAGS: frozenset[str] = frozenset(
+    {
+        "-destroy",
+        "-backend-config",
+        "-migrate-state",
+        "-state",
+        "-force-unlock",
+        "-reconfigure",
+    }
+)
+
+
+def _validate_extra_args(args: list[str]) -> list[str]:
+    """Validate parsed extra args against the allowlist.
+
+    Raises:
+        typer.Exit: If any arg uses a blocked or unknown flag.
+    """
+    validated: list[str] = []
+
+    for arg in args:
+        flag = arg.split("=", 1)[0] if "=" in arg else arg
+
+        if flag in BLOCKED_EXTRA_ARG_FLAGS:
+            console.print(f"[red]❌ Blocked extra arg: {flag}[/red]")
+            console.print(
+                "[red]This flag is explicitly blocked for safety. "
+                "It cannot be passed via PR comments.[/red]"
+            )
+            raise typer.Exit(1)
+
+        if flag not in ALLOWED_EXTRA_ARG_FLAGS:
+            console.print(f"[red]❌ Unknown extra arg flag: {flag}[/red]")
+            console.print(f"[red]Allowed flags: {', '.join(sorted(ALLOWED_EXTRA_ARG_FLAGS))}[/red]")
+            raise typer.Exit(1)
+
+        validated.append(arg)
+
+    return validated
+
+
 def _parse_extra_args(raw: str) -> list[str]:
     """Parse extra args string into list, handling shell quoting.
 
@@ -346,6 +401,7 @@ def execute(
 
     if raw_extra_args:
         parsed_extra_args = _parse_extra_args(raw_extra_args)
+        parsed_extra_args = _validate_extra_args(parsed_extra_args)
         console.print(f"[cyan]📝 Extra args from command:[/cyan] {parsed_extra_args}")
 
     table = Table(title="Terraform Execution")

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess  # nosec B404 - subprocess is required to run terraform
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -17,7 +18,17 @@ from rich.console import Console
 
 TF_INPUT_FALSE = "-input=false"
 
+_VAR_REDACT_RE = re.compile(r"(-var=\S+?=)(\S+)")
+
 console = Console()
+
+
+def _redact_args(args: list[str]) -> str:
+    """Join args for display, redacting -var= values."""
+    redacted = []
+    for arg in args:
+        redacted.append(_VAR_REDACT_RE.sub(r"\1***", arg))
+    return " ".join(redacted)
 
 
 @dataclass
@@ -94,7 +105,7 @@ class TerraformExecutor:
         if env:
             full_env.update(env)
 
-        console.print(f"[dim]$ {' '.join(args)}[/dim]")
+        console.print(f"[dim]$ {_redact_args(args)}[/dim]")
 
         result = subprocess.run(  # nosec B603 B607 - args from validated config, terraform via PATH is expected
             args,

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import subprocess  # nosec B404 - subprocess is required to run terraform
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,16 +17,40 @@ from rich.console import Console
 
 TF_INPUT_FALSE = "-input=false"
 
-_VAR_REDACT_RE = re.compile(r"(-var=\S+?=)(\S+)")
-
 console = Console()
 
 
+def _redact_single_arg(arg: str) -> str:
+    """Redact a single arg if it contains a -var= value."""
+    if arg.startswith("-var="):
+        eq_pos = arg.find("=", 5)
+        if eq_pos != -1:
+            return arg[: eq_pos + 1] + "***"
+    return arg
+
+
 def _redact_args(args: list[str]) -> str:
-    """Join args for display, redacting -var= values."""
-    redacted = []
-    for arg in args:
-        redacted.append(_VAR_REDACT_RE.sub(r"\1***", arg))
+    """Join args for display, redacting -var= values.
+
+    Handles both ``-var=key=value`` (single token) and
+    ``-var key=value`` (two-token) forms, including values that
+    contain spaces.
+    """
+    redacted: list[str] = []
+    skip_next = False
+    for i, arg in enumerate(args):
+        if skip_next:
+            redacted.append("***")
+            skip_next = False
+            continue
+        redacted_arg = _redact_single_arg(arg)
+        if redacted_arg is not arg and redacted_arg != arg:
+            redacted.append(redacted_arg)
+        elif arg == "-var" and i + 1 < len(args):
+            redacted.append(arg)
+            skip_next = True
+        else:
+            redacted.append(arg)
     return " ".join(redacted)
 
 

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -44,7 +44,7 @@ def _redact_args(args: list[str]) -> str:
             skip_next = False
             continue
         redacted_arg = _redact_single_arg(arg)
-        if redacted_arg is not arg and redacted_arg != arg:
+        if redacted_arg != arg:
             redacted.append(redacted_arg)
         elif arg == "-var" and i + 1 < len(args):
             redacted.append(arg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,14 +5,18 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from tf_branch_deploy.cli import (
+    ALLOWED_EXTRA_ARG_FLAGS,
+    BLOCKED_EXTRA_ARG_FLAGS,
     DEFAULT_CONFIG_PATH,
     _ArgTokenizer,
     _load_and_validate_config,
     _parse_extra_args,
     _strip_shell_quotes,
+    _validate_extra_args,
     app,
 )
 
@@ -60,6 +64,67 @@ class TestParseExtraArgs:
         """Test preserving spaces within quoted values."""
         result = _parse_extra_args("-var='message=hello world foo bar'")
         assert result == ["-var=message=hello world foo bar"]
+
+
+class TestValidateExtraArgs:
+    """Tests for _validate_extra_args function."""
+
+    def test_allowed_flags_pass(self) -> None:
+        """Allowed flags pass validation."""
+        args = ["-target=module.base", "-refresh=false", "-parallelism=5"]
+        result = _validate_extra_args(args)
+        assert result == args
+
+    def test_var_allowed(self) -> None:
+        """The -var flag is allowed."""
+        args = ["-var=key=value"]
+        assert _validate_extra_args(args) == args
+
+    def test_destroy_blocked(self) -> None:
+        """The -destroy flag is blocked."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-destroy"])
+
+    def test_backend_config_blocked(self) -> None:
+        """The -backend-config flag is blocked."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-backend-config=key=value"])
+
+    def test_state_blocked(self) -> None:
+        """The -state flag is blocked."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-state=/tmp/evil.tfstate"])
+
+    def test_migrate_state_blocked(self) -> None:
+        """The -migrate-state flag is blocked."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-migrate-state"])
+
+    def test_unknown_flag_blocked(self) -> None:
+        """Unknown flags that aren't in the allowlist are blocked."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-some-unknown-flag=value"])
+
+    def test_mixed_valid_then_blocked_fails(self) -> None:
+        """If any arg is blocked, the whole set fails."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-target=module.base", "-destroy"])
+
+    def test_empty_list_passes(self) -> None:
+        """Empty args list passes validation."""
+        assert _validate_extra_args([]) == []
+
+    def test_all_allowed_flags_accepted(self) -> None:
+        """All flags in ALLOWED_EXTRA_ARG_FLAGS pass validation."""
+        args = [f"{flag}=test" for flag in sorted(ALLOWED_EXTRA_ARG_FLAGS)]
+        result = _validate_extra_args(args)
+        assert len(result) == len(ALLOWED_EXTRA_ARG_FLAGS)
+
+    def test_all_blocked_flags_rejected(self) -> None:
+        """All flags in BLOCKED_EXTRA_ARG_FLAGS are rejected."""
+        for flag in BLOCKED_EXTRA_ARG_FLAGS:
+            with pytest.raises(typer.Exit):
+                _validate_extra_args([flag])
 
 
 class TestStripShellQuotes:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -402,3 +402,18 @@ class TestRedactArgs:
         result = _redact_args(args)
         assert "-var=token=***" in result
         assert "-target=module.foo" in result
+
+    def test_var_with_spaces_fully_redacted(self) -> None:
+        """Value containing spaces in a single token is fully redacted."""
+        args = ["terraform", "plan", "-var=msg=hello world"]
+        assert _redact_args(args) == "terraform plan -var=msg=***"
+
+    def test_two_token_var_redacted(self) -> None:
+        """-var key=value (two tokens) redacts the value token."""
+        args = ["terraform", "plan", "-var", "password=s3cr3t"]
+        assert _redact_args(args) == "terraform plan -var ***"
+
+    def test_two_token_var_at_end(self) -> None:
+        """-var at end of args (no value following) is left as-is."""
+        args = ["terraform", "plan", "-var"]
+        assert _redact_args(args) == "terraform plan -var"

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -9,6 +9,7 @@ from tf_branch_deploy.executor import (
     CommandResult,
     PlanResult,
     TerraformExecutor,
+    _redact_args,
 )
 
 
@@ -370,3 +371,34 @@ class TestVersion:
         """version() returns 'unknown' on malformed JSON."""
         mock_run.return_value = MagicMock(returncode=0, stdout="not json", stderr="")
         assert executor.version() == "unknown"
+
+
+class TestRedactArgs:
+    """Tests for _redact_args log redaction."""
+
+    def test_no_vars_unchanged(self) -> None:
+        """Args without -var= are unchanged."""
+        args = ["terraform", "plan", "-target=module.base"]
+        assert _redact_args(args) == "terraform plan -target=module.base"
+
+    def test_var_value_redacted(self) -> None:
+        """The value part of -var=key=value is replaced with ***."""
+        args = ["terraform", "plan", "-var=password=s3cr3t"]
+        assert _redact_args(args) == "terraform plan -var=password=***"
+
+    def test_multiple_vars_redacted(self) -> None:
+        """Multiple -var= args are all redacted."""
+        args = ["terraform", "plan", "-var=a=1", "-var=b=2"]
+        assert _redact_args(args) == "terraform plan -var=a=*** -var=b=***"
+
+    def test_var_file_not_redacted(self) -> None:
+        """-var-file= is NOT the same as -var= and should not be redacted."""
+        args = ["terraform", "plan", "-var-file=vars.tfvars"]
+        assert _redact_args(args) == "terraform plan -var-file=vars.tfvars"
+
+    def test_mixed_args(self) -> None:
+        """Mix of -var, -target, and plain args."""
+        args = ["terraform", "apply", "-var=token=abc123", "-target=module.foo"]
+        result = _redact_args(args)
+        assert "-var=token=***" in result
+        assert "-target=module.foo" in result


### PR DESCRIPTION
## Summary

Addresses **Issue #120** — Command Injection Protection (HIGH severity findings #4 and #7 from safety audit).

### Finding #4: Arbitrary flag injection via PR comments

PR comment parameters (e.g. `.plan dev | -target=module.base`) flow through `_parse_extra_args()` unvalidated. A malicious actor could inject dangerous flags like `-destroy`, `-backend-config`, `-state`, or `-force-unlock`.

**Fix:** Allowlist-based validation of all extra args before they reach terraform:
- `ALLOWED_EXTRA_ARG_FLAGS`: `-target`, `-var`, `-var-file`, `-refresh`, `-parallelism`, `-compact-warnings`, `-lock`, `-lock-timeout`, `-replace`
- `BLOCKED_EXTRA_ARG_FLAGS`: `-destroy`, `-backend-config`, `-migrate-state`, `-state`, `-force-unlock`, `-reconfigure`
- Unknown flags are blocked by default (allowlist approach, not blocklist)
- Validation wired into execute flow between parsing and consumption

### Finding #7: Command logging exposes sensitive args

`_run_command()` logged full args including `-var=key=VALUE` — leaking secrets in CI logs.

**Fix:** `_redact_args()` helper replaces value portion of `-var=key=VALUE` with `-var=key=***` in log output only. Actual subprocess args are untouched.

### Tests

- 11 new tests for `_validate_extra_args`: allowed flags pass, each blocked flag rejected, unknown flags rejected, mixed args, empty list, exhaustive allowlist/blocklist coverage
- 5 new tests for `_redact_args`: no vars unchanged, single/multiple var redaction, var-file not redacted, mixed args

**All 122 tests passing.** Pre-commit (ruff, mypy, bandit) all clean.

Closes #120