### PR TITLE
fix(#122): lifecycle robustness & test assertion fix

### DIFF
--- a/src/tf_branch_deploy/lifecycle.py
+++ b/src/tf_branch_deploy/lifecycle.py
@@ -58,8 +58,10 @@ class LifecycleManager:
             ]
             self._run_gh(cmd)
         except Exception as e:
-            # Ignore errors removing reactions, but log for debug
-            console.print(f"[dim]Ignored error removing reaction: {e}[/dim]")
+            console.print(
+                f"[yellow]⚠️  Non-critical: failed to remove reaction "
+                f"(comment={comment_id}, reaction={reaction_id}): {e}[/yellow]"
+            )
 
     def add_reaction(self, comment_id: str, content: str) -> None:
         """Add a reaction to a comment."""
@@ -139,9 +141,11 @@ class LifecycleManager:
                 f"repos/{self.repo}/contents/lock.json", ref=lock_ref
             )
             sticky = content_json.get("sticky", "false")
-        except Exception:
-            # If we can't read the lock file, assume it's sticky to be safe
-            console.print("[yellow]   ⚠️  Could not read lock metadata - assuming sticky[/yellow]")
+        except Exception as e:
+            console.print(
+                f"[yellow]⚠️  Non-critical: could not read lock metadata "
+                f"(environment={environment}): {e} — assuming sticky[/yellow]"
+            )
             sticky = "true"
 
         if str(sticky).lower() == "true":
@@ -159,7 +163,10 @@ class LifecycleManager:
             ]
             self._run_gh(cmd)
         except Exception as e:
-            console.print(f"[dim]Ignored error removing lock: {e}[/dim]")
+            console.print(
+                f"[yellow]⚠️  Non-critical: failed to remove lock "
+                f"(environment={environment}): {e}[/yellow]"
+            )
 
     def _gh_api(self, method: str, endpoint: str, **kwargs: Any) -> Any:
         """Call gh api."""
@@ -170,23 +177,19 @@ class LifecycleManager:
         return self._run_gh(args)
 
     def _gh_api_get_content(self, endpoint: str, ref: str) -> dict[str, Any]:
-        """Get file content from GitHub API."""
-        # Using gh api to get raw content is tricky with base64 decoding.
-        # Use jq to extract content and decode.
-        # Can we rely on python's json/base64?
-        # Let's use `gh api ... --jq .content` and decode in python.
+        """Get file content from GitHub API.
+
+        Raises on any failure so callers can handle it explicitly.
+        """
         import base64
 
         cmd = ["gh", "api", endpoint, "-f", f"ref={ref}", "--jq", ".content"]
         result = self._run_gh(cmd, capture_output=True)
         if not result:
-            return {}
+            raise RuntimeError("gh api returned empty response")
 
-        try:
-            decoded = base64.b64decode(result).decode("utf-8")
-            return json.loads(decoded)
-        except Exception:
-            return {}
+        decoded = base64.b64decode(result).decode("utf-8")
+        return json.loads(decoded)
 
     def _run_gh(self, cmd: list[str], capture_output: bool = False) -> str | None:
         """Run gh command.
@@ -218,7 +221,10 @@ class LifecycleManager:
             )
             if result.returncode != 0:
                 if not capture_output:
-                    console.print(f"[dim]gh command failed: {result.stderr}[/dim]")
+                    console.print(
+                        f"[yellow]⚠️  gh command failed (exit {result.returncode}): "
+                        f"{result.stderr.strip()}[/yellow]"
+                    )
                 return None
             return result.stdout.strip()
         except Exception as e:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -24,10 +24,9 @@ class TestLifecycleManager:
 
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
-        args_str = " ".join(args)
-        assert "gh" in args_str
-        assert "deployments/123/statuses" in args_str
-        assert "state=success" in args_str
+        assert "gh" in args
+        assert any("deployments/123/statuses" in a for a in args)
+        assert "state=success" in args
 
     @patch("tf_branch_deploy.lifecycle.subprocess.run")
     def test_remove_reaction(self, mock_run: MagicMock, manager: LifecycleManager) -> None:
@@ -36,9 +35,8 @@ class TestLifecycleManager:
 
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
-        args_str = " ".join(args)
-        assert "DELETE" in args_str
-        assert "issues/comments/456/reactions/789" in args_str
+        assert "DELETE" in args
+        assert any("issues/comments/456/reactions/789" in a for a in args)
 
     @patch("tf_branch_deploy.lifecycle.subprocess.run")
     def test_add_reaction(self, mock_run: MagicMock, manager: LifecycleManager) -> None:
@@ -47,10 +45,9 @@ class TestLifecycleManager:
 
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
-        args_str = " ".join(args)
-        assert "POST" in args_str
-        assert "issues/comments/456/reactions" in args_str
-        assert "content=rocket" in args_str
+        assert "POST" in args
+        assert any("issues/comments/456/reactions" in a for a in args)
+        assert "content=rocket" in args
 
     @patch("tf_branch_deploy.lifecycle.subprocess.run")
     def test_post_result_comment(self, mock_run: MagicMock, manager: LifecycleManager) -> None:
@@ -59,9 +56,8 @@ class TestLifecycleManager:
 
         mock_run.assert_called_once()
         args = mock_run.call_args[0][0]
-        args_str = " ".join(args)
-        assert "issues/100/comments" in args_str
-        assert "body=body" in args_str
+        assert any("issues/100/comments" in a for a in args)
+        assert "body=body" in args
 
     def test_format_result_comment_success(self, manager: LifecycleManager) -> None:
         """Test formatting success comment."""


### PR DESCRIPTION
## Summary

Addresses Issue #122: Lifecycle Robustness & Test Fix — the final issue from the safety audit.

### Finding #11 — Structured warnings for suppressed errors
Replaced dim/silent error suppression in `lifecycle.py` with structured yellow warnings that include operation context. Errors in non-critical lifecycle operations (removing reactions, reading lock metadata, removing locks, gh CLI failures) are now clearly visible with:
- Yellow ⚠️ prefix for visual prominence
- Operation context (what was being attempted)
- Parameter values for debugging
- The actual error message

### Finding #16 — Test assertion fix
Changed all `test_lifecycle.py` assertions from substring match (`in " ".join(args)`) to element match (`in args` / `any(x in a for a in args)`). The previous pattern could false-positive if a value appeared as a substring of another argument.

### Tests
All 133 tests pass.

Closes #122