### PR TITLE
refactor: simplify terraform argument validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
-      - uses: actions/setup-python@4f41a90a1f38628c7ccc608d05fbafe701bc20ae # v5.3.0
+      - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -11,35 +11,30 @@ permissions:
   statuses: read
 
 jobs:
-  dispatch:
+  parse:
     if: github.event.issue.pull_request
     runs-on: ubuntu-latest
-    env:
-      SOURCE_REPOSITORY: ${{ github.repository }}
-      TARGET_REPOSITORY: scarowar/test-terraform-branch-deploy
-      PR_NUMBER: ${{ github.event.issue.number }}
-      COMMENT_ID: ${{ github.event.comment.id }}
-      COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+    outputs:
+      run: ${{ steps.command.outputs.run }}
+      stage: ${{ steps.command.outputs.stage }}
     steps:
-      - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Parse E2E command
         id: command
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
-          COMMENT_BODY="$(
-            gh api \
-              "repos/${SOURCE_REPOSITORY}/issues/comments/${COMMENT_ID}" \
-              --jq '.body'
+          body="$(
+            python3 - <<'PY'
+          import json
+          import os
+
+          with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as event_file:
+              event = json.load(event_file)
+          print(event.get("comment", {}).get("body") or "")
+          PY
           )"
-          body="$(printf '%s' "${COMMENT_BODY}" | tr -d '\r')"
+          body="$(printf '%s' "${body}" | tr -d '\r')"
           body="${body#"${body%%[![:space:]]*}"}"
           body="${body%"${body##*[![:space:]]}"}"
 
@@ -52,13 +47,88 @@ jobs:
           echo "run=true" >> "${GITHUB_OUTPUT}"
           echo "stage=${stage}" >> "${GITHUB_OUTPUT}"
 
-      - name: Validate requester
-        if: steps.command.outputs.run == 'true'
+  dispatch:
+    needs: parse
+    if: needs.parse.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      checks: read
+      statuses: read
+      issues: write
+    env:
+      SOURCE_REPOSITORY: ${{ github.repository }}
+      TARGET_REPOSITORY: scarowar/test-terraform-branch-deploy
+      PR_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_ID: ${{ github.event.comment.id }}
+      COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Validate and dispatch external E2E
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          DISPATCH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}
+          CERTIFICATION_STAGE: ${{ needs.parse.outputs.stage }}
         run: |
           set -euo pipefail
+
+          comment_file="${RUNNER_TEMP}/tfbd-e2e-comment.md"
+          tracking_comment_id=""
+          candidate_ref="pending"
+
+          write_comment() {
+            local status="$1"
+            local detail="$2"
+
+            cat > "${comment_file}" <<EOF
+          ### External E2E
+
+          - Stage: \`${CERTIFICATION_STAGE}\`
+          - Candidate: \`${candidate_ref}\`
+          - Requested by: @${COMMENT_AUTHOR}
+          - Status: ${status}
+
+          ${detail}
+
+          <!-- terraform-branch-deploy-e2e:${PR_NUMBER}:${COMMENT_ID} -->
+          EOF
+          }
+
+          create_tracking_comment() {
+            write_comment "queued" "Validating the pull request before dispatching the external E2E workflow."
+            tracking_comment_id="$(
+              jq -n --rawfile body "${comment_file}" '{body: $body}' |
+                gh api \
+                  --method POST \
+                  "repos/${SOURCE_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                  --input - \
+                  --jq '.id'
+            )"
+          }
+
+          update_tracking_comment() {
+            write_comment "$1" "$2"
+            jq -n --rawfile body "${comment_file}" '{body: $body}' |
+              gh api \
+                --method PATCH \
+                "repos/${SOURCE_REPOSITORY}/issues/comments/${tracking_comment_id}" \
+                --input - >/dev/null
+          }
+
+          fail_with_comment() {
+            local message="$1"
+            echo "::error::${message}"
+            if [ -n "${tracking_comment_id}" ]; then
+              update_tracking_comment "not started" "${message}"
+            fi
+            exit 1
+          }
 
           permission="$(
             gh api \
@@ -74,51 +144,34 @@ jobs:
               ;;
           esac
 
-      - name: Validate pull request state
-        if: steps.command.outputs.run == 'true'
-        id: pr
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
+          create_tracking_comment
 
           pr_json="$(
             gh pr view "${PR_NUMBER}" \
               --repo "${SOURCE_REPOSITORY}" \
-              --json state,isDraft,baseRefName,headRefOid,reviewDecision,mergeStateStatus
+              --json state,isDraft,baseRefName,headRefOid,mergeStateStatus
           )"
 
           state="$(jq -r '.state' <<< "${pr_json}")"
           is_draft="$(jq -r '.isDraft' <<< "${pr_json}")"
           base_ref="$(jq -r '.baseRefName' <<< "${pr_json}")"
-          head_sha="$(jq -r '.headRefOid' <<< "${pr_json}")"
-          review_decision="$(jq -r '.reviewDecision // ""' <<< "${pr_json}")"
+          candidate_ref="$(jq -r '.headRefOid' <<< "${pr_json}")"
           merge_state="$(jq -r '.mergeStateStatus // ""' <<< "${pr_json}")"
 
           if [ "${state}" != "OPEN" ]; then
-            echo "::error::Pull request #${PR_NUMBER} is not open."
-            exit 1
+            fail_with_comment "Pull request #${PR_NUMBER} is not open."
           fi
 
           if [ "${is_draft}" = "true" ]; then
-            echo "::error::Pull request #${PR_NUMBER} is a draft."
-            exit 1
+            fail_with_comment "Pull request #${PR_NUMBER} is a draft."
           fi
 
           if [ "${base_ref}" != "main" ]; then
-            echo "::error::External E2E only runs for pull requests targeting main."
-            exit 1
-          fi
-
-          if [ "${review_decision}" != "APPROVED" ]; then
-            echo "::error::Pull request #${PR_NUMBER} must be approved before external E2E."
-            exit 1
+            fail_with_comment "External E2E only runs for pull requests targeting main."
           fi
 
           if [ "${merge_state}" = "DIRTY" ]; then
-            echo "::error::Pull request #${PR_NUMBER} is not mergeable."
-            exit 1
+            fail_with_comment "Pull request #${PR_NUMBER} is not mergeable."
           fi
 
           checks_json="$(
@@ -130,8 +183,7 @@ jobs:
           )"
 
           if [ -z "${checks_json}" ]; then
-            echo "::error::Could not read pull request checks."
-            exit 1
+            fail_with_comment "Could not read pull request checks."
           fi
 
           failing_checks="$(
@@ -139,9 +191,11 @@ jobs:
               <<< "${checks_json}"
           )"
           if [ -n "${failing_checks}" ]; then
-            echo "::error::Pull request checks must pass before external E2E."
-            printf '%s\n' "${failing_checks}"
-            exit 1
+            fail_with_comment "Pull request checks must pass before external E2E.
+
+          \`\`\`
+          ${failing_checks}
+          \`\`\`"
           fi
 
           current_head_sha="$(
@@ -150,33 +204,35 @@ jobs:
               --json headRefOid \
               --jq '.headRefOid'
           )"
-          if [ "${current_head_sha}" != "${head_sha}" ]; then
-            echo "::error::Pull request head changed during validation. Re-run /e2e."
-            exit 1
+          if [ "${current_head_sha}" != "${candidate_ref}" ]; then
+            fail_with_comment "Pull request head changed during validation. Re-run /e2e."
           fi
 
-          echo "head-sha=${head_sha}" >> "${GITHUB_OUTPUT}"
-
-      - name: Dispatch external E2E
-        if: steps.command.outputs.run == 'true'
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}
-          CANDIDATE_REF: ${{ steps.pr.outputs.head-sha }}
-          CERTIFICATION_STAGE: ${{ steps.command.outputs.stage }}
-        run: |
-          set -euo pipefail
+          if [ -z "${DISPATCH_TOKEN}" ]; then
+            fail_with_comment "TFBD_E2E_DISPATCH_TOKEN is not configured."
+          fi
 
           payload="$(
             jq -n \
               --arg ref "main" \
-              --arg candidate_ref "${CANDIDATE_REF}" \
+              --arg candidate_ref "${candidate_ref}" \
               --arg source_pr "${PR_NUMBER}" \
               --arg stage "${CERTIFICATION_STAGE}" \
-              '{ref: $ref, inputs: {candidate_ref: $candidate_ref, source_pr: $source_pr, stage: $stage}}'
+              --arg tracking_comment_id "${tracking_comment_id}" \
+              '{ref: $ref, inputs: {candidate_ref: $candidate_ref, source_pr: $source_pr, stage: $stage, tracking_comment_id: $tracking_comment_id}}'
           )"
 
-          gh api \
+          if ! dispatch_error="$(
+            GH_TOKEN="${DISPATCH_TOKEN}" gh api \
             --method POST \
             "repos/${TARGET_REPOSITORY}/actions/workflows/e2e-tests.yml/dispatches" \
-            --input - <<< "${payload}"
+            --input - <<< "${payload}" 2>&1
+          )"; then
+            fail_with_comment "Could not dispatch external E2E. Verify TFBD_E2E_DISPATCH_TOKEN has Actions: write on ${TARGET_REPOSITORY}.
+
+          \`\`\`
+          ${dispatch_error}
+          \`\`\`"
+          fi
+
+          update_tracking_comment "dispatched" "The external E2E workflow has been dispatched. This comment will be updated when the external run starts and completes."

--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -174,6 +174,69 @@ def _redact_args_for_display(args: list[str]) -> list[str]:
     return [_redact_single_arg(arg) for arg in args]
 
 
+def _arg_flag(arg: str) -> str:
+    """Return the flag portion of a Terraform argument."""
+    return arg.split("=", 1)[0] if "=" in arg else arg
+
+
+def _arg_has_inline_value(arg: str) -> bool:
+    """Return whether a Terraform argument carries its value with '='."""
+    return "=" in arg
+
+
+def _fail_arg_validation(message: str) -> None:
+    """Print a validation error and stop command execution."""
+    console.print(f"[red]❌ {message}[/red]")
+    raise typer.Exit(1)
+
+
+def _validate_arg_token(arg: str, source: str) -> str:
+    """Validate a single Terraform argument token and return its flag."""
+    if not arg.startswith("-"):
+        _fail_arg_validation(f"Unsupported {source} arg value without flag: {arg}")
+    return _arg_flag(arg)
+
+
+def _validate_arg_flag(
+    flag: str,
+    allowed_flags: frozenset[str],
+    source: str,
+) -> None:
+    """Validate a Terraform argument flag against the source allowlist."""
+    if flag not in BLOCKED_EXTRA_ARG_FLAGS and flag in allowed_flags:
+        return
+
+    console.print(f"[red]❌ Unsupported {source} arg: {flag}[/red]")
+    console.print(f"[red]Allowed {source} flags: {', '.join(sorted(allowed_flags))}[/red]")
+    raise typer.Exit(1)
+
+
+def _next_arg_value(args: list[str], index: int) -> str | None:
+    """Return the separate value after a flag, when one exists."""
+    value_index = index + 1
+    if value_index >= len(args) or args[value_index].startswith("-"):
+        return None
+    return args[value_index]
+
+
+def _separate_value_for_arg(
+    args: list[str],
+    index: int,
+    flag: str,
+    source: str,
+) -> str | None:
+    """Return a required or optional separate flag value."""
+    if flag in ARG_FLAGS_WITH_SEPARATE_VALUES:
+        if value := _next_arg_value(args, index):
+            return value
+        _fail_arg_validation(f"Missing value for {source} arg: {flag}")
+
+    if flag in ARG_FLAGS_WITH_OPTIONAL_SEPARATE_VALUES:
+        return _next_arg_value(args, index)
+
+    return None
+
+
 def _validate_args_allowed(
     args: list[str],
     allowed_flags: frozenset[str],
@@ -185,28 +248,13 @@ def _validate_args_allowed(
 
     while i < len(args):
         arg = args[i]
-        if not arg.startswith("-"):
-            console.print(f"[red]❌ Unsupported {source} arg value without flag: {arg}[/red]")
-            raise typer.Exit(1)
-
-        flag = arg.split("=", 1)[0] if "=" in arg else arg
-
-        if flag in BLOCKED_EXTRA_ARG_FLAGS or flag not in allowed_flags:
-            console.print(f"[red]❌ Unsupported {source} arg: {flag}[/red]")
-            console.print(f"[red]Allowed {source} flags: {', '.join(sorted(allowed_flags))}[/red]")
-            raise typer.Exit(1)
-
+        flag = _validate_arg_token(arg, source)
+        _validate_arg_flag(flag, allowed_flags, source)
         validated.append(arg)
 
-        if "=" not in arg and flag in ARG_FLAGS_WITH_SEPARATE_VALUES:
-            if i + 1 >= len(args) or args[i + 1].startswith("-"):
-                console.print(f"[red]❌ Missing value for {source} arg: {flag}[/red]")
-                raise typer.Exit(1)
-            validated.append(args[i + 1])
-            i += 1
-        elif "=" not in arg and flag in ARG_FLAGS_WITH_OPTIONAL_SEPARATE_VALUES:
-            if i + 1 < len(args) and not args[i + 1].startswith("-"):
-                validated.append(args[i + 1])
+        if not _arg_has_inline_value(arg):
+            if value := _separate_value_for_arg(args, i, flag, source):
+                validated.append(value)
                 i += 1
 
         i += 1

--- a/tests/contract/test_workflow_security_contract.py
+++ b/tests/contract/test_workflow_security_contract.py
@@ -54,6 +54,11 @@ def test_jobs_start_with_step_security_harden_runner() -> None:
     for path in WORKFLOW_FILES:
         workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
         for job_name, job in workflow.get("jobs", {}).items():
+            if path == E2E_DISPATCH_WORKFLOW and job_name == "parse":
+                run_commands = "\n".join(step.get("run", "") for step in job.get("steps", []))
+                assert "gh api" not in run_commands
+                assert "actions/checkout" not in run_commands
+                continue
             steps = job.get("steps", [])
             if not steps:
                 continue
@@ -137,19 +142,29 @@ def test_external_e2e_dispatch_is_maintainer_gated() -> None:
     """The /e2e broker should dispatch exact PR heads without running PR code."""
     workflow = yaml.safe_load(E2E_DISPATCH_WORKFLOW.read_text(encoding="utf-8"))
     workflow_text = E2E_DISPATCH_WORKFLOW.read_text(encoding="utf-8")
+    parse_job = workflow["jobs"]["parse"]
     job = workflow["jobs"]["dispatch"]
+    parse_commands = "\n".join(step.get("run", "") for step in parse_job["steps"])
     run_commands = "\n".join(step.get("run", "") for step in job["steps"])
 
     assert "issue_comment" in workflow[True]
     assert "actions/checkout" not in workflow_text
     assert "pull_request_target" not in workflow_text
+    assert "issues" not in workflow["permissions"]
+    assert job["permissions"]["issues"] == "write"
+    assert job["needs"] == "parse"
     assert "TFBD_E2E_DISPATCH_TOKEN" in workflow_text
     assert "TFBD_STATUS_TOKEN" not in workflow_text
     assert "/e2e" in workflow_text
+    assert "GITHUB_EVENT_PATH" in parse_commands
+    assert "gh api" not in parse_commands
     assert "admin|maintain|write" in run_commands
-    assert "review_decision" in run_commands
-    assert 'review_decision}" != "APPROVED"' in run_commands
+    assert "reviewDecision" not in workflow_text
+    assert "review_decision" not in run_commands
     assert "gh pr checks" in run_commands
     assert "terraform-branch-deploy/e2e" in run_commands
     assert "current_head_sha" in run_commands
     assert "actions/workflows/e2e-tests.yml/dispatches" in run_commands
+    assert "issues/${PR_NUMBER}/comments" in run_commands
+    assert "issues/comments/${tracking_comment_id}" in run_commands
+    assert "tracking_comment_id" in run_commands


### PR DESCRIPTION
## Summary
- split Terraform argument validation into focused helpers
- preserve existing allowlist, split-value, and apply/rollback behavior

## Validation
- uv run pytest
- uv run pre-commit run --all-files --show-diff-on-failure