### PR TITLE
ci: fix external e2e broker comment permissions

### DIFF
--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -56,7 +56,6 @@ jobs:
       pull-requests: read
       checks: read
       statuses: read
-      issues: write
     env:
       SOURCE_REPOSITORY: ${{ github.repository }}
       TARGET_REPOSITORY: scarowar/test-terraform-branch-deploy
@@ -72,8 +71,7 @@ jobs:
       - name: Validate and dispatch external E2E
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
-          DISPATCH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}
           CERTIFICATION_STAGE: ${{ needs.parse.outputs.stage }}
         run: |
           set -euo pipefail
@@ -208,7 +206,7 @@ jobs:
             fail_with_comment "Pull request head changed during validation. Re-run /e2e."
           fi
 
-          if [ -z "${DISPATCH_TOKEN}" ]; then
+          if [ -z "${GH_TOKEN}" ]; then
             fail_with_comment "TFBD_E2E_DISPATCH_TOKEN is not configured."
           fi
 
@@ -223,7 +221,7 @@ jobs:
           )"
 
           if ! dispatch_error="$(
-            GH_TOKEN="${DISPATCH_TOKEN}" gh api \
+            gh api \
             --method POST \
             "repos/${TARGET_REPOSITORY}/actions/workflows/e2e-tests.yml/dispatches" \
             --input - <<< "${payload}" 2>&1

--- a/tests/contract/test_workflow_security_contract.py
+++ b/tests/contract/test_workflow_security_contract.py
@@ -151,13 +151,15 @@ def test_external_e2e_dispatch_is_maintainer_gated() -> None:
     assert "actions/checkout" not in workflow_text
     assert "pull_request_target" not in workflow_text
     assert "issues" not in workflow["permissions"]
-    assert job["permissions"]["issues"] == "write"
+    assert "issues" not in job["permissions"]
     assert job["needs"] == "parse"
     assert "TFBD_E2E_DISPATCH_TOKEN" in workflow_text
     assert "TFBD_STATUS_TOKEN" not in workflow_text
     assert "/e2e" in workflow_text
     assert "GITHUB_EVENT_PATH" in parse_commands
     assert "gh api" not in parse_commands
+    assert "GH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}" in workflow_text
+    assert "GH_TOKEN: ${{ github.token }}" not in workflow_text
     assert "admin|maintain|write" in run_commands
     assert "reviewDecision" not in workflow_text
     assert "review_decision" not in run_commands


### PR DESCRIPTION
Fixes the merged /e2e broker by using the cross-repo broker token for source PR progress comments and external workflow dispatch, while keeping the workflow GITHUB_TOKEN read-only.

Validation so far:
- uv run pytest
- uv run pre-commit run --all-files
- broker token can read maintainer permission as admin

After this is merged, a fresh empty validation PR will be used to confirm the merged broker creates and updates the tracking comment.