### PR TITLE
test: harden enterprise compatibility contracts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,9 +16,9 @@ Do not release if action inputs, outputs, commands, or docs are out of sync.
 
 ## Version References
 
-- Update `docs/includes/version.txt` to the candidate release tag.
-- Run `scripts/update-version.sh`.
-- Confirm every public Terraform Branch Deploy action example points at the same candidate tag.
+- Public docs should keep `scarowar/terraform-branch-deploy@v0` unless a page is intentionally showing an exact release.
+- For release validation, use the exact candidate SHA or release tag in the external E2E repository.
+- If the public docs version policy changes, update `docs/includes/version.txt`, run `scripts/update-version.sh`, and review the resulting diff before committing.
 
 ## Security Gates
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -224,6 +224,8 @@ For self-hosted GitHub Enterprise and AWS CodeBuild runners, prefer preinstallin
 
 The action reuses matching preinstalled tools where it can. For Terraform, set `terraform-version` to the exact preinstalled version when public downloads are not available. If a runner cannot reach public download hosts, preinstall these tools or populate the runner tool cache instead of adding action inputs for internal tool versions.
 
+On GitHub Enterprise Cloud data residency or GitHub Enterprise Server, the action still uses the workflow `github-token` for Branch Deploy, comments, deployments, and lifecycle cleanup. It does not pass that Enterprise-scoped token to uv's public GitHub release lookup.
+
 ## Debug Logs
 
 Enable GitHub Actions debug logging from repository settings, or set these secrets to `true`:

--- a/tests/contract/test_action_runtime_contract.py
+++ b/tests/contract/test_action_runtime_contract.py
@@ -75,6 +75,7 @@ class TestCompositeRuntimeContract:
         assert setup_step["with"]["working-directory"] == "${{ github.action_path }}"
         assert "github.server_url == 'https://github.com'" in setup_step["with"]["github-token"]
         assert "inputs.github-token" in setup_step["with"]["github-token"]
+        assert "|| ''" in setup_step["with"]["github-token"]
 
     def test_trigger_mode_exports_state_required_by_execute_mode(
         self, action: dict[str, Any]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -341,6 +341,32 @@ class TestTfcmtIntegration:
             call_args = mock_run.call_args[0][0]
             assert call_args == ["terraform", "plan"]
 
+    @patch("tf_branch_deploy.executor.subprocess.run")
+    def test_run_with_tfcmt_preserves_enterprise_actions_api_env(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """tfcmt should inherit GitHub Actions Enterprise API endpoint variables."""
+        executor = TerraformExecutor(
+            working_directory=tmp_path,
+            github_token="test-token",
+            repo="org/repo",
+            pr_number=123,
+        )
+        monkeypatch.setenv("GITHUB_API_URL", "https://git.company.com/api/v3")
+        monkeypatch.setenv("GITHUB_GRAPHQL_URL", "https://git.company.com/api/graphql")
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        executor._run_with_tfcmt("plan", ["terraform", "plan"])
+
+        call_env = mock_run.call_args.kwargs["env"]
+        assert call_env["GITHUB_TOKEN"] == "test-token"
+        assert call_env["GITHUB_API_URL"] == "https://git.company.com/api/v3"
+        assert call_env["GITHUB_GRAPHQL_URL"] == "https://git.company.com/api/graphql"
+
 
 class TestVersion:
     """Tests for TerraformExecutor.version()."""

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -260,22 +260,36 @@ class TestLifecycleManager:
         assert call_env["GH_TOKEN"] == "test-token"
         assert call_env["GH_ENTERPRISE_TOKEN"] == "test-token"
 
+    @pytest.mark.parametrize(
+        ("server_url", "expected_host"),
+        [
+            ("https://company.ghe.com", "company.ghe.com"),
+            ("https://git.i.company.com", "git.i.company.com"),
+        ],
+    )
     @patch("tf_branch_deploy.lifecycle.subprocess.run")
-    def test_run_gh_sets_gh_host_for_ghe(
-        self, mock_run: MagicMock, manager: LifecycleManager
+    def test_run_gh_sets_gh_host_for_enterprise_hosts(
+        self,
+        mock_run: MagicMock,
+        manager: LifecycleManager,
+        server_url: str,
+        expected_host: str,
     ) -> None:
-        """Test that GH_HOST is set from GITHUB_SERVER_URL for self-hosted GHE."""
+        """GitHub CLI calls must target GHEC data residency and GHES hosts."""
         mock_result = MagicMock()
         mock_result.returncode = 0
         mock_run.return_value = mock_result
 
-        ghe_env = {"GITHUB_SERVER_URL": "https://git.i.company.com"}
+        ghe_env = {"GITHUB_SERVER_URL": server_url}
 
         with patch.dict(os.environ, ghe_env, clear=True):
             manager._run_gh(["gh", "api", "repos/org/repo/issues"])
 
         call_env = mock_run.call_args[1]["env"]
-        assert call_env["GH_HOST"] == "git.i.company.com"
+        assert call_env["GH_HOST"] == expected_host
+        assert call_env["GITHUB_TOKEN"] == "test-token"
+        assert call_env["GH_TOKEN"] == "test-token"
+        assert call_env["GH_ENTERPRISE_TOKEN"] == "test-token"
 
     @patch("tf_branch_deploy.lifecycle.subprocess.run")
     def test_run_gh_does_not_set_gh_host_for_github_com(


### PR DESCRIPTION
## Summary

- add explicit GHEC data residency and GHES lifecycle token/host contract coverage
- add tfcmt Enterprise API endpoint inheritance coverage
- clarify v0 release reference policy and Enterprise tool-install behavior

## Verification

- uv run pytest
- uv run pre-commit run --all-files
- uv run zensical build --strict --clean

External E2E was not run.