### PR TITLE
fix: harden release security paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,8 +43,8 @@ body:
     id: version
     attributes:
       label: "Action version"
-      description: "Which version of terraform-branch-deploy are you using? (e.g., v1.2.3)"
-      placeholder: "v1.2.3"
+      description: "Which terraform-branch-deploy tag or commit SHA are you using?"
+      placeholder: "v0 or a full commit SHA"
     validations:
       required: false
   - type: textarea
@@ -57,9 +57,12 @@ body:
         ```yaml
         jobs:
           deploy:
-            uses: scarowar/terraform-branch-deploy@v0.2.0
-            with:
-              ...
+            runs-on: ubuntu-latest
+            steps:
+              - uses: scarowar/terraform-branch-deploy@v0
+                with:
+                  mode: trigger
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
         ```
       render: yaml
     validations:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ Thank you for your contribution! Please review the checklist below before submit
 
 - [ ] My pull request addresses a single issue or concern
 - [ ] I have described the changes clearly
-- [ ] I have run all pre-commit checks (`pre-commit run --all-files`)
-- [ ] I have updated documentation as needed (e.g., `README.md`)
-- [ ] I have tested the changes (if applicable)
+- [ ] I have run tests (`uv run pytest`)
+- [ ] I have run pre-commit (`uv run pre-commit run --all-files`)
+- [ ] I have built docs when documentation changed (`uv run zensical build --strict --clean`)
 - [ ] I have checked for breaking changes
 
 ## Description

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -128,6 +128,10 @@ jobs:
             exit 1
           }
 
+          if [ -z "${GH_TOKEN}" ]; then
+            fail_with_comment "TFBD_E2E_DISPATCH_TOKEN is not configured."
+          fi
+
           permission="$(
             gh api \
               "repos/${SOURCE_REPOSITORY}/collaborators/${COMMENT_AUTHOR}/permission" \
@@ -225,10 +229,6 @@ jobs:
               exit 0
               ;;
           esac
-
-          if [ -z "${GH_TOKEN}" ]; then
-            fail_with_comment "TFBD_E2E_DISPATCH_TOKEN is not configured."
-          fi
 
           payload="$(
             jq -n \

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -206,6 +206,26 @@ jobs:
             fail_with_comment "Pull request head changed during validation. Re-run /e2e."
           fi
 
+          status_context="terraform-branch-deploy/e2e"
+          if [ "${CERTIFICATION_STAGE}" != "all" ]; then
+            status_context="${status_context}-${CERTIFICATION_STAGE}"
+          fi
+          existing_status="$(
+            gh api \
+              "repos/${SOURCE_REPOSITORY}/commits/${candidate_ref}/status" \
+              --jq "first(.statuses[] | select(.context == \"${status_context}\") | .state) // \"\""
+          )"
+          case "${existing_status}" in
+            pending)
+              update_tracking_comment "not started" "External E2E ${CERTIFICATION_STAGE} is already running for this pull request head."
+              exit 0
+              ;;
+            success)
+              update_tracking_comment "not started" "External E2E ${CERTIFICATION_STAGE} already passed for this pull request head."
+              exit 0
+              ;;
+          esac
+
           if [ -z "${GH_TOKEN}" ]; then
             fail_with_comment "TFBD_E2E_DISPATCH_TOKEN is not configured."
           fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -16,6 +16,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       # Needed for Code scanning upload
       security-events: write
       # Needed for GitHub OIDC token if publish_results is true

--- a/action.yml
+++ b/action.yml
@@ -646,7 +646,7 @@ runs:
       if: inputs.mode == 'execute'
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        TFBD_GITHUB_TOKEN: ${{ inputs.github-token }}
         TF_BD_EXTRA_ARGS: ${{ env.TF_BD_PARAMS }}
         INPUT_CONFIG_PATH: ${{ inputs.config-path }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -142,7 +142,7 @@ prod:
 ## Complete Example
 
 ```yaml title=".tf-branch-deploy.yml"
-# yaml-language-server: $schema=https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/main/tf-branch-deploy.schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/v0/tf-branch-deploy.schema.json
 
 default-environment: dev
 production-environments: [prod, prod-eu]
@@ -198,7 +198,7 @@ Enable editor validation with the generated JSON schema.
     Add this comment to `.tf-branch-deploy.yml`:
 
     ```yaml
-    # yaml-language-server: $schema=https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/main/tf-branch-deploy.schema.json
+    # yaml-language-server: $schema=https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/v0/tf-branch-deploy.schema.json
     ```
 
 === "JetBrains IDEs"
@@ -212,7 +212,7 @@ Enable editor validation with the generated JSON schema.
     | File pattern | `.tf-branch-deploy.yml` |
 
     ```text
-    https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/main/tf-branch-deploy.schema.json
+    https://raw.githubusercontent.com/scarowar/terraform-branch-deploy/v0/tf-branch-deploy.schema.json
     ```
 
 The action validates the configuration during execute mode. Unknown fields are rejected.

--- a/docs/security.md
+++ b/docs/security.md
@@ -115,7 +115,7 @@ The apply restores the saved targeted plan. It does not create a fresh plan.
 Rollback uses the stable branch:
 
 ```text
-.apply main to prod
+.apply main to dev
 ```
 
 Rollback is intentionally separate from normal apply. It applies the stable branch directly and does not require a saved pull request plan.
@@ -159,6 +159,15 @@ A workflow may do an initial default-branch checkout before trigger mode so the 
 ```
 
 This keeps cloud credentials behind Branch Deploy's command, permission, check, and lock decisions.
+
+## GitHub Token Isolation
+
+The `github-token` input is used for Branch Deploy, PR comments, deployments,
+and lifecycle cleanup. Terraform subprocesses do not receive that token as
+`GITHUB_TOKEN`.
+
+If Terraform itself needs to call the GitHub API, provide a separate,
+least-privileged credential only after trigger mode has accepted the command.
 
 For production workflows, pin third-party actions such as `actions/checkout` and cloud authentication actions by full commit SHA. The examples in these docs use version tags for readability.
 

--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -15,6 +15,7 @@ import os
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -28,7 +29,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from .config import load_config
-from .executor import _redact_single_arg
+from .executor import _redact_args
 
 DEFAULT_CONFIG_PATH = Path(".tf-branch-deploy.yml")
 GITHUB_URL_DEFAULT = "https://github.com"
@@ -169,9 +170,17 @@ NON_PLAN_EXTRA_ARGS_ERROR = (
 )
 
 
-def _redact_args_for_display(args: list[str]) -> list[str]:
+def _package_version() -> str:
+    """Return the installed package version for command output."""
+    try:
+        return version("tf-branch-deploy")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _redact_args_for_display(args: list[str]) -> str:
     """Redact argument values before showing PR-supplied or metadata args."""
-    return [_redact_single_arg(arg) for arg in args]
+    return _redact_args(args)
 
 
 def _arg_flag(arg: str) -> str:
@@ -316,10 +325,7 @@ def _print_execution_table(
     table.add_row("Working Dir", str(working_dir))
     table.add_row("Dry Run", str(dry_run))
     if parsed_extra_args:
-        table.add_row(
-            "Extra Args",
-            " ".join(_redact_single_arg(arg) for arg in parsed_extra_args),
-        )
+        table.add_row("Extra Args", _redact_args_for_display(parsed_extra_args))
     console.print(table)
 
 
@@ -334,9 +340,9 @@ def _print_dry_run_commands(
     """Print the Terraform commands that would run in dry-run mode."""
     console.print("\n[yellow]🧪 Dry run - commands would be:[/yellow]")
     console.print(f"  cd {working_dir}")
-    console.print(f"  terraform init {' '.join(init_args)}")
+    console.print(f"  {_redact_args(['terraform', 'init', *init_args])}")
     if operation == "plan":
-        console.print(f"  terraform plan {' '.join(plan_args)}")
+        console.print(f"  {_redact_args(['terraform', 'plan', *plan_args])}")
     elif operation == "apply":
         console.print("  terraform apply <saved plan file>")
     else:
@@ -344,7 +350,7 @@ def _print_dry_run_commands(
         for var_file in var_files:
             rollback_args.extend(["-var-file", var_file])
         rollback_args.extend(apply_args)
-        console.print(f"  terraform apply {' '.join(rollback_args)}")
+        console.print(f"  {_redact_args(['terraform', 'apply', *rollback_args])}")
 
 
 def _pr_number_from_env() -> int | None:
@@ -591,7 +597,10 @@ def execute(
       .plan to dev | -target=module.base -target=module.network
     """
     console.print(
-        Panel.fit("[bold blue]Terraform Branch Deploy[/bold blue] v0.2.0", subtitle="Execute Mode")
+        Panel.fit(
+            f"[bold blue]Terraform Branch Deploy[/bold blue] v{_package_version()}",
+            subtitle="Execute Mode",
+        )
     )
 
     config, env_config = _load_and_validate_config(config_path, environment)
@@ -636,7 +645,7 @@ def execute(
         init_args=init_args,
         plan_args=plan_args,
         apply_args=apply_args,
-        github_token=os.environ.get("GITHUB_TOKEN"),
+        github_token=os.environ.get("TFBD_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN"),
         repo=os.environ.get("GITHUB_REPOSITORY"),
         pr_number=_pr_number_from_env(),
         timeout=env_config.timeout,
@@ -651,7 +660,7 @@ def execute(
         raise typer.Exit(1)
 
     if operation == "plan":
-        _handle_plan(executor, environment, sha, plan_args, var_files)
+        _handle_plan(executor, environment, sha, plan_args, var_files, raw_extra_args)
     else:
         _handle_apply(
             executor,
@@ -670,11 +679,28 @@ def _handle_plan(
     sha: str,
     plan_args: list[str],
     var_files: list[str],
+    raw_extra_args: str | None = None,
 ) -> None:
     """Handle terraform plan operation."""
 
     plan_file = Path(f"tfplan-{environment}-{sha[:8]}.tfplan")
     result = executor.plan(out_file=plan_file)
+    if not result.success:
+        logs_url = (
+            os.environ.get("GITHUB_SERVER_URL", GITHUB_URL_DEFAULT)
+            + "/"
+            + os.environ.get("GITHUB_REPOSITORY", "")
+            + ACTIONS_RUNS_PATH
+            + os.environ.get("GITHUB_RUN_ID", "")
+        )
+        error_msg = format_error_for_comment(
+            message="Terraform plan failed. The `terraform plan` command exited with an error.",
+            logs_url=logs_url,
+            suggestion=f"Fix any configuration errors and run `.plan to {environment}` again",
+        )
+        set_github_output("failure_reason", error_msg)
+        raise typer.Exit(1)
+
     if result.plan_file and result.checksum:
         set_github_output("plan_file", str(result.plan_file))
         set_github_output("plan_checksum", result.checksum)
@@ -683,7 +709,7 @@ def _handle_plan(
         # Save plan metadata sidecar for cross-run integrity verification
         from .artifacts import PlanMetadata, generate_params_hash, save_plan_metadata
 
-        extra_args_str = os.environ.get("TF_BD_EXTRA_ARGS", "")
+        extra_args_str = raw_extra_args or ""
         tf_version = executor.version()
         params_hash = generate_params_hash(extra_args_str)
 
@@ -703,22 +729,6 @@ def _handle_plan(
 
         set_github_output("plan_params_hash", params_hash)
         set_github_output("plan_terraform_version", tf_version)
-
-    if not result.success:
-        logs_url = (
-            os.environ.get("GITHUB_SERVER_URL", GITHUB_URL_DEFAULT)
-            + "/"
-            + os.environ.get("GITHUB_REPOSITORY", "")
-            + ACTIONS_RUNS_PATH
-            + os.environ.get("GITHUB_RUN_ID", "")
-        )
-        error_msg = format_error_for_comment(
-            message="Terraform plan failed. The `terraform plan` command exited with an error.",
-            logs_url=logs_url,
-            suggestion=f"Fix any configuration errors and run `.plan to {environment}` again",
-        )
-        set_github_output("failure_reason", error_msg)
-        raise typer.Exit(1)
 
 
 def _handle_apply(
@@ -880,7 +890,7 @@ def _apply_with_plan(
     if metadata.extra_args:
         console.print(
             "[dim]📝 Plan was created with args: "
-            f"{' '.join(_redact_args_for_display(metadata.extra_args))}[/dim]"
+            f"{_redact_args_for_display(metadata.extra_args)}[/dim]"
         )
     console.print(f"[dim]📝 Plan created at: {metadata.created_at}[/dim]")
 

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -2,7 +2,7 @@
 Terraform executor module.
 
 Handles terraform init, plan, and apply operations with proper
-argument resolution and PR comment posting via tfcmt.
+argument resolution and optional PR comment posting via tfcmt.
 """
 
 from __future__ import annotations
@@ -16,6 +16,12 @@ from pathlib import Path
 from rich.console import Console
 
 TF_INPUT_FALSE = "-input=false"
+GITHUB_TOKEN_ENV_VARS = (
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GH_ENTERPRISE_TOKEN",
+    "TFBD_GITHUB_TOKEN",
+)
 
 console = Console()
 
@@ -125,9 +131,7 @@ class TerraformExecutor:
         env: dict[str, str] | None = None,
     ) -> CommandResult:
         """Run a command and capture output."""
-        full_env = os.environ.copy()
-        if env:
-            full_env.update(env)
+        full_env = self._subprocess_env(env)
 
         console.print(f"[dim]$ {_redact_args(args)}[/dim]")
 
@@ -332,15 +336,31 @@ class TerraformExecutor:
                 ["tfcmt", "--version"],
                 capture_output=True,
                 text=True,
+                env=self._subprocess_env(),
             )
             return result.returncode == 0
         except FileNotFoundError:
             return False
 
+    @staticmethod
+    def _subprocess_env(env: dict[str, str] | None = None) -> dict[str, str]:
+        """Build a subprocess environment that does not leak GitHub tokens to Terraform."""
+        full_env = os.environ.copy()
+        for name in GITHUB_TOKEN_ENV_VARS:
+            full_env.pop(name, None)
+        if env:
+            full_env.update(env)
+        return full_env
+
     def _run_with_tfcmt(self, operation: str, tf_args: list[str]) -> CommandResult:
         """Run terraform command wrapped with tfcmt for PR comments."""
         if not self.github_token or not self.repo or not self.pr_number:
             return self._run_command(tf_args)
+
+        scrubbed_tf_args = ["env"]
+        for name in GITHUB_TOKEN_ENV_VARS:
+            scrubbed_tf_args.extend(["-u", name])
+        scrubbed_tf_args.extend(tf_args)
 
         args = [
             "tfcmt",
@@ -352,7 +372,7 @@ class TerraformExecutor:
             str(self.pr_number),
             operation,
             "--",
-        ] + tf_args
+        ] + scrubbed_tf_args
 
         env = {"GITHUB_TOKEN": self.github_token}
         return self._run_command(args, env=env)

--- a/src/tf_branch_deploy/executor.py
+++ b/src/tf_branch_deploy/executor.py
@@ -372,7 +372,8 @@ class TerraformExecutor:
             str(self.pr_number),
             operation,
             "--",
-        ] + scrubbed_tf_args
+            *scrubbed_tf_args,
+        ]
 
         env = {"GITHUB_TOKEN": self.github_token}
         return self._run_command(args, env=env)

--- a/tests/contract/test_action_runtime_contract.py
+++ b/tests/contract/test_action_runtime_contract.py
@@ -241,6 +241,17 @@ class TestCompositeRuntimeContract:
         assert "TF_BD_EXTRA_ARGS: ${{ env.TF_BD_PARAMS }}" not in script
         assert "--extra-args" not in script
 
+    def test_execute_mode_does_not_expose_github_token_as_provider_env(
+        self, action: dict[str, Any]
+    ) -> None:
+        """The deployment token must not be exported as GITHUB_TOKEN during Terraform."""
+        execute_step = step_by_id(action, "tf-execute")
+        lifecycle_step = step_by_name(action, "[Execute] Complete Deployment Lifecycle")
+
+        assert "GITHUB_TOKEN" not in execute_step["env"]
+        assert execute_step["env"]["TFBD_GITHUB_TOKEN"] == "${{ inputs.github-token }}"
+        assert lifecycle_step["env"]["GITHUB_TOKEN"] == "${{ inputs.github-token }}"
+
     def test_shell_steps_do_not_interpolate_action_inputs_directly(
         self, action: dict[str, Any]
     ) -> None:

--- a/tests/contract/test_workflow_security_contract.py
+++ b/tests/contract/test_workflow_security_contract.py
@@ -166,6 +166,9 @@ def test_external_e2e_dispatch_is_maintainer_gated() -> None:
     assert "gh pr checks" in run_commands
     assert "terraform-branch-deploy/e2e" in run_commands
     assert "current_head_sha" in run_commands
+    assert "commits/${candidate_ref}/status" in run_commands
+    assert "already running for this pull request head" in run_commands
+    assert "already passed for this pull request head" in run_commands
     assert "actions/workflows/e2e-tests.yml/dispatches" in run_commands
     assert "issues/${PR_NUMBER}/comments" in run_commands
     assert "issues/comments/${tracking_comment_id}" in run_commands

--- a/tests/contract/test_workflow_security_contract.py
+++ b/tests/contract/test_workflow_security_contract.py
@@ -160,6 +160,12 @@ def test_external_e2e_dispatch_is_maintainer_gated() -> None:
     assert "gh api" not in parse_commands
     assert "GH_TOKEN: ${{ secrets.TFBD_E2E_DISPATCH_TOKEN }}" in workflow_text
     assert "GH_TOKEN: ${{ github.token }}" not in workflow_text
+    assert run_commands.index('if [ -z "${GH_TOKEN}" ]; then') < run_commands.index(
+        '"repos/${SOURCE_REPOSITORY}/collaborators/${COMMENT_AUTHOR}/permission"'
+    )
+    assert run_commands.index('if [ -z "${GH_TOKEN}" ]; then') < run_commands.index(
+        '"repos/${SOURCE_REPOSITORY}/commits/${candidate_ref}/status"'
+    )
     assert "admin|maintain|write" in run_commands
     assert "reviewDecision" not in workflow_text
     assert "review_decision" not in run_commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ from tf_branch_deploy.cli import (
     BLOCKED_EXTRA_ARG_FLAGS,
     DEFAULT_CONFIG_PATH,
     _ArgTokenizer,
+    _handle_plan,
     _apply_with_plan,
     _handle_apply,
     _load_and_validate_config,
@@ -515,6 +516,53 @@ class TestCompleteLifecycleCommand:
         mock_manager.remove_non_sticky_lock.assert_called_with("dev")
 
 
+class TestHandlePlan:
+    """Tests for plan output and metadata handling."""
+
+    def test_failed_plan_does_not_emit_saved_plan_outputs_or_metadata(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failed plan must not turn a stale plan file into a saved-plan artifact."""
+        from unittest.mock import MagicMock
+
+        from tf_branch_deploy.executor import PlanResult
+
+        output_file = tmp_path / "github-output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+
+        stale_plan = tmp_path / "tfplan-int-abc12345.tfplan"
+        stale_plan.write_bytes(b"stale plan")
+
+        mock_executor = MagicMock()
+        mock_executor.plan.return_value = PlanResult(
+            exit_code=1,
+            stdout="",
+            stderr="plan failed",
+            command=["terraform", "plan"],
+            has_changes=False,
+            plan_file=stale_plan,
+            checksum="not-a-real-checksum",
+        )
+
+        with pytest.raises(typer.Exit):
+            _handle_plan(
+                mock_executor,
+                "int",
+                "abc12345ff",
+                plan_args=[],
+                var_files=[],
+                raw_extra_args="",
+            )
+
+        output_text = output_file.read_text(encoding="utf-8")
+        assert "failure_reason" in output_text
+        assert "plan_file" not in output_text
+        assert "plan_checksum" not in output_text
+        assert not stale_plan.with_suffix(".meta.json").exists()
+
+
 class TestHandleApply:
     """Tests for _handle_apply — rollback priority and plan file resolution."""
 
@@ -987,6 +1035,56 @@ class TestExecuteArgumentSemantics:
 
         assert result.exit_code == 0
         assert "terraform plan -parallelism=20 -target=module.database" in result.stdout
+
+    def test_plan_dry_run_redacts_inline_var_values(self, tmp_path: Path) -> None:
+        config_file = self._write_config(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "execute",
+                "--environment",
+                "int",
+                "--operation",
+                "plan",
+                "--sha",
+                "abc12345ff",
+                "--config",
+                str(config_file),
+                "--dry-run",
+                "--extra-args",
+                "-var=token=super-secret",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "super-secret" not in result.stdout
+        assert "-var=token=***" in result.stdout
+
+    def test_plan_dry_run_redacts_split_var_values(self, tmp_path: Path) -> None:
+        config_file = self._write_config(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "execute",
+                "--environment",
+                "int",
+                "--operation",
+                "plan",
+                "--sha",
+                "abc12345ff",
+                "--config",
+                str(config_file),
+                "--dry-run",
+                "--extra-args",
+                "-var token=super-secret",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "super-secret" not in result.stdout
+        assert "-var ***" in result.stdout
 
     def test_apply_dry_run_never_shows_apply_args_for_saved_plan(self, tmp_path: Path) -> None:
         config_file = self._write_config(

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -7,6 +7,7 @@ import pytest
 
 from tf_branch_deploy.executor import (
     CommandResult,
+    GITHUB_TOKEN_ENV_VARS,
     PlanResult,
     TerraformExecutor,
     _redact_args,
@@ -66,6 +67,24 @@ class TestTerraformExecutor:
         assert result.exit_code == 0
         assert result.stdout == "success output"
         mock_run.assert_called_once()
+
+    @patch("tf_branch_deploy.executor.subprocess.run")
+    def test_run_command_removes_github_tokens_from_subprocess_env(
+        self,
+        mock_run: MagicMock,
+        executor: TerraformExecutor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Terraform subprocesses must not receive GitHub deployment tokens."""
+        for name in GITHUB_TOKEN_ENV_VARS:
+            monkeypatch.setenv(name, f"{name}-value")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        executor._run_command(["terraform", "plan"])
+
+        call_env = mock_run.call_args.kwargs["env"]
+        for name in GITHUB_TOKEN_ENV_VARS:
+            assert name not in call_env
 
     @patch("subprocess.run")
     def test_init_builds_correct_command(
@@ -362,10 +381,25 @@ class TestTfcmtIntegration:
 
         executor._run_with_tfcmt("plan", ["terraform", "plan"])
 
+        call_args = mock_run.call_args.args[0]
         call_env = mock_run.call_args.kwargs["env"]
         assert call_env["GITHUB_TOKEN"] == "test-token"
+        assert "TFBD_GITHUB_TOKEN" not in call_env
         assert call_env["GITHUB_API_URL"] == "https://git.company.com/api/v3"
         assert call_env["GITHUB_GRAPHQL_URL"] == "https://git.company.com/api/graphql"
+        assert call_args[-11:] == [
+            "env",
+            "-u",
+            "GITHUB_TOKEN",
+            "-u",
+            "GH_TOKEN",
+            "-u",
+            "GH_ENTERPRISE_TOKEN",
+            "-u",
+            "TFBD_GITHUB_TOKEN",
+            "terraform",
+            "plan",
+        ]
 
 
 class TestVersion:


### PR DESCRIPTION
## Summary
- keep the Terraform execution step from exporting the Branch Deploy GitHub token as GITHUB_TOKEN
- scrub GitHub token env vars from Terraform subprocesses while allowing tfcmt to post comments through a scrubbed child command
- prevent failed plans from writing saved-plan outputs or metadata, and redact var values in CLI display paths
- add /e2e duplicate suppression and tighten docs/templates found in release review

## Verification
- uv run pytest
- uv run zensical build --strict --clean
- uv run pre-commit run --all-files

External live E2E was not run.