### PR TITLE
docs: avoid release-specific fork support comment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -439,7 +439,7 @@ runs:
         admins_pat: ${{ inputs.admins-pat }}
         commit_verification: ${{ inputs.commit-verification }}
         disable_naked_commands: ${{ inputs.disable-naked-commands }}
-        # Terraform Branch Deploy v0.2.0 does not support forked PR execution.
+        # Terraform Branch Deploy does not support forked PR execution yet.
         # Fork-aware checkout and lifecycle handling will be added only with
         # explicit tests for Branch Deploy's fork outputs.
         allow_forks: "false"


### PR DESCRIPTION
## Summary
- make the fork-support implementation comment version-neutral

## Verification
- uv run pytest tests/contract/test_branch_deploy_compat.py tests/contract/test_action_runtime_contract.py
- uv run pytest
- uv run zensical build --strict --clean
- uv run pre-commit run --all-files