### PR TITLE
fix: address v0.2.0 release blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to Terraform Branch Deploy are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.2.0] - 2026-05-26
+
+### Added
+
+- Two-mode GitHub Action flow with separate `trigger` and `execute` phases.
+- Environment configuration through `.tf-branch-deploy.yml`.
+- Saved Terraform plan files with metadata and checksum verification.
+- Terraform plan, apply, rollback, lock, unlock, and status workflows through Branch Deploy commands.
+- GitHub Enterprise Cloud and GitHub Enterprise Server compatible token handling for runtime setup.
+
+### Changed
+
+- Normal apply now requires the latest successful saved plan for the same environment and commit.
+- Extra Terraform arguments from PR comments are accepted only on plan commands.
+- Rollback uses the configured stable branch directly and does not consume pull request saved plans.
+- Documentation now separates quickstart, configuration, command reference, security, troubleshooting, and upgrading guidance.
+
+### Fixed
+
+- Targeted plans followed by plain apply use the saved targeted plan instead of running a fresh untargeted apply.
+- Deployment lifecycle completion now releases non-sticky Branch Deploy locks after successful operations.
+- Plan metadata validation now blocks stale, missing, mismatched, or tampered saved plans before apply.
+
+### Security
+
+- PR comment `-var-file` paths are restricted to relative paths inside the environment working directory.
+- Direct normal apply without a saved plan is blocked.
+- Workflow guidance now keeps privileged checkout and cloud credentials behind Branch Deploy approval.
+
+## [0.1.0] - 2025-07-27
+
+### Added
+
+- Initial Terraform Branch Deploy action release.
+
+[0.2.0]: https://github.com/scarowar/terraform-branch-deploy/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/scarowar/terraform-branch-deploy/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Targeted plans followed by plain apply use the saved targeted plan instead of running a fresh untargeted apply.
 - Deployment lifecycle completion now releases non-sticky Branch Deploy locks after successful operations.
 - Plan metadata validation now blocks stale, missing, mismatched, or tampered saved plans before apply.
+- Apply now refuses restored plans when the cache key params hash and saved metadata params hash do not match.
 
 ### Security
 
-- PR comment `-var-file` paths are restricted to relative paths inside the environment working directory.
+- PR comment `-var-file` paths are restricted to relative paths inside the environment working directory after symlink resolution.
 - Direct normal apply without a saved plan is blocked.
 - Workflow guidance now keeps privileged checkout and cloud credentials behind Branch Deploy approval.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Branch Deploy's model is deploy before merge:
 3. Comment `.apply to <env>` to apply the saved plan.
 4. Merge after the environment has been applied successfully.
 
-For normal applies, the action restores the saved plan for the same environment and commit SHA. Rollbacks use Branch Deploy's stable branch command shape:
+For normal applies, the action restores the latest successful saved plan for the same environment and commit SHA. Rollbacks use Branch Deploy's stable branch command shape:
 
 ```text
 .apply main to prod
@@ -98,7 +98,7 @@ After reviewing the plan, apply it:
 | Command | Purpose |
 | --- | --- |
 | `.plan to <env>` | Run `terraform plan`, post the result, and save the plan. |
-| `.apply to <env>` | Apply the saved plan for the same environment and commit. |
+| `.apply to <env>` | Apply the latest successful saved plan for the same environment and commit. |
 | `.apply main to <env>` | Roll back by applying the stable branch directly. |
 | `.lock <env>` | Lock an environment. |
 | `.unlock <env>` | Release a lock. |
@@ -121,12 +121,16 @@ Those arguments belong on the plan that creates the saved plan file. Rollback
 applies the stable branch directly; Terraform does not provide a deterministic
 target-only undo operation.
 
+If you run another successful plan for the same environment and commit, that
+newer plan is the one a later `.apply to <env>` uses.
+
 ## Documentation
 
 | Resource | Use it for |
 | --- | --- |
 | [Quickstart](https://scarowar.github.io/terraform-branch-deploy/quickstart/) | First working workflow. |
 | [Upgrading](https://scarowar.github.io/terraform-branch-deploy/upgrading/) | Changes to review before moving between releases. |
+| [Changelog](CHANGELOG.md) | Versioned release history. |
 | [How It Works](https://scarowar.github.io/terraform-branch-deploy/concepts/modes/) | How the two action modes fit in one job. |
 | [Configuration](https://scarowar.github.io/terraform-branch-deploy/configuration/) | Environment and Terraform settings. |
 | [Commands](https://scarowar.github.io/terraform-branch-deploy/reference/commands/) | PR comment command reference. |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Branch Deploy's model is deploy before merge:
 3. Comment `.apply to <env>` to apply the saved plan.
 4. Merge after the environment has been applied successfully.
 
-For normal applies, the action restores the latest successful saved plan for the same environment and commit SHA. Rollbacks use Branch Deploy's stable branch command shape:
+For normal applies, the action restores the latest successful saved plan for the same environment and commit SHA. The restored cache key and saved metadata must agree on the plan argument hash before Terraform runs. Rollbacks use Branch Deploy's stable branch command shape:
 
 ```text
 .apply main to prod

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -67,6 +67,7 @@ Watch these flows explicitly:
 - Add a regression test for every critical bug fix.
 - Keep release changes small and directly tested.
 - Keep docs and maintainer instructions short, canonical, and non-duplicative.
+- Draft release notes from `CHANGELOG.md` and the tag diff. Keep them factual and user-facing.
 - Keep public commands, outputs, environment variables, plan naming, cache keys, and rollback behavior stable unless a test proves they are wrong.
 - Normal apply must use a saved `.tfplan` file.
 - Direct apply without a saved plan is reserved for rollback.

--- a/action.yml
+++ b/action.yml
@@ -613,34 +613,25 @@ runs:
     # Uses prefix matching via restore-keys to find the latest successful plan
     # for this environment and commit. A newer successful plan supersedes older
     # plans for the same environment and commit. Each plan run has a unique key
-    # (run_id + run_attempt), preventing cache collision when re-planning.
+    # (params hash + run_id + run_attempt), preventing cache collision when
+    # re-planning with different PR comment arguments.
     #
     # ACCEPTED RISK: actions/cache is evictable (10GB repo limit) and
     # not an independent trust domain. The CLI handles cache misses safely
     # by aborting with "no plan file found" rather than falling through
     # to an untargeted apply. Plan integrity is further protected by the
-    # metadata sidecar checksum verified in the CLI.
+    # metadata sidecar checksum and params hash verified in the CLI.
     - name: "[Execute] Restore Cached Plan"
+      id: restore-plan
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       if: inputs.mode == 'execute' && env.TF_BD_OPERATION == 'apply'
       with:
         path: |
           **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.tfplan
           **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.meta.json
-        key: tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-${{ github.run_id }}-${{ github.run_attempt }}
+        key: tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-no-args-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
           tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-
-
-    # Cache plan file after plan operations (auto-saves in post-job on cache miss).
-    # Key includes run_id + run_attempt for uniqueness — re-plans never collide.
-    - name: "[Execute] Cache Plan File"
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      if: inputs.mode == 'execute' && env.TF_BD_OPERATION == 'plan'
-      with:
-        path: |
-          **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.tfplan
-          **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.meta.json
-        key: tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     - name: "[Execute] Run Terraform"
       id: tf-execute
@@ -649,6 +640,7 @@ runs:
       env:
         TFBD_GITHUB_TOKEN: ${{ inputs.github-token }}
         TF_BD_EXTRA_ARGS: ${{ env.TF_BD_PARAMS }}
+        TF_BD_PLAN_CACHE_KEY: ${{ steps.restore-plan.outputs.cache-matched-key }}
         INPUT_CONFIG_PATH: ${{ inputs.config-path }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
         TFBD_BIN: ${{ runner.temp }}/tf-bd-venv/bin/tf-branch-deploy
@@ -672,6 +664,18 @@ runs:
           --sha "${TF_BD_SHA}" \
           --config "${INPUT_CONFIG_PATH}" \
           $DRY_RUN_FLAG
+
+    # Cache plan files only after the CLI has saved the metadata sidecar.
+    # The key includes the params hash emitted by the CLI so apply can prove
+    # the restored plan matches the Terraform arguments used for planning.
+    - name: "[Execute] Cache Plan File"
+      uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      if: inputs.mode == 'execute' && env.TF_BD_OPERATION == 'plan' && steps.tf-execute.outputs.plan_params_hash != ''
+      with:
+        path: |
+          **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.tfplan
+          **/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.meta.json
+        key: tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-${{ steps.tf-execute.outputs.plan_params_hash }}-${{ github.run_id }}-${{ github.run_attempt }}
 
     - name: "[Execute] Complete Deployment Lifecycle"
       if: inputs.mode == 'execute' && always()

--- a/action.yml
+++ b/action.yml
@@ -610,8 +610,9 @@ runs:
         echo "✅ State validated: ${TF_BD_ENVIRONMENT} / ${TF_BD_OPERATION}"
 
     # Restore cached plan for apply operations.
-    # Uses prefix matching via restore-keys to find the most recent plan
-    # for this environment and commit. Each plan run has a unique key
+    # Uses prefix matching via restore-keys to find the latest successful plan
+    # for this environment and commit. A newer successful plan supersedes older
+    # plans for the same environment and commit. Each plan run has a unique key
     # (run_id + run_attempt), preventing cache collision when re-planning.
     #
     # ACCEPTED RISK: actions/cache is evictable (10GB repo limit) and

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -41,7 +41,7 @@ For safer workflows, use `disable-naked-commands: true` in the action inputs so 
 
 Paths are resolved relative to the environment `working-directory`.
 
-Normal apply is intentionally plan-file based: `.apply to <env>` restores the latest successful saved plan for the same environment and commit SHA, then passes that plan file to Terraform. It does not add `var-files` or `apply-args` again. Extra Terraform arguments from PR comments are accepted only on `.plan`.
+Normal apply is intentionally plan-file based: `.apply to <env>` restores the latest successful saved plan for the same environment and commit SHA, then passes that plan file to Terraform. The restored cache key and saved metadata must agree on the plan argument hash. It does not add `var-files` or `apply-args` again. Extra Terraform arguments from PR comments are accepted only on `.plan`.
 
 Rollback applies the stable branch directly. It does not accept PR comment
 arguments such as `-target`, because Terraform does not provide a deterministic

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -41,7 +41,7 @@ For safer workflows, use `disable-naked-commands: true` in the action inputs so 
 
 Paths are resolved relative to the environment `working-directory`.
 
-Normal apply is intentionally plan-file based: `.apply to <env>` restores the saved plan for the same environment and commit SHA, then passes that plan file to Terraform. It does not add `var-files` or `apply-args` again. Extra Terraform arguments from PR comments are accepted only on `.plan`.
+Normal apply is intentionally plan-file based: `.apply to <env>` restores the latest successful saved plan for the same environment and commit SHA, then passes that plan file to Terraform. It does not add `var-files` or `apply-args` again. Extra Terraform arguments from PR comments are accepted only on `.plan`.
 
 Rollback applies the stable branch directly. It does not accept PR comment
 arguments such as `-target`, because Terraform does not provide a deterministic

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ For targeted plans, keep apply simple:
 .apply to prod
 ```
 
-The apply step uses the saved targeted plan. It does not create a new untargeted apply, and extra Terraform arguments are rejected on apply.
+The apply step uses the saved targeted plan. It does not create a new untargeted apply, and extra Terraform arguments are rejected on apply. The restored cache key and saved metadata must agree before Terraform runs.
 
 If you run another successful plan for the same environment and commit, that
 newer plan is the one a later apply uses.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Terraform Branch Deploy brings that model to Terraform:
 | --- | --- | --- |
 | Plan | `.plan to dev` | Runs `terraform plan`, posts the result, and saves the plan for the commit and environment. |
 | Review | Read the plan comment | Review additions, changes, destroys, and warnings before applying. |
-| Apply | `.apply to dev` | Restores and applies the saved plan. |
+| Apply | `.apply to dev` | Restores and applies the latest successful saved plan. |
 | Roll back | `.apply main to prod` | Applies the stable branch directly. |
 
 A normal pull request workflow stays inside GitHub:
@@ -76,6 +76,9 @@ For targeted plans, keep apply simple:
 
 The apply step uses the saved targeted plan. It does not create a new untargeted apply, and extra Terraform arguments are rejected on apply.
 
+If you run another successful plan for the same environment and commit, that
+newer plan is the one a later apply uses.
+
 **Targeted plans keep their Terraform arguments in the saved plan**
 
 ![Targeted Terraform plan warning in GitHub](assets/images/workflow/06-targeted-plan-warning.png)
@@ -105,7 +108,7 @@ Then comment on a pull request:
 | Command | Purpose |
 | --- | --- |
 | `.plan to <env>` | Run `terraform plan`, post the result, and save the plan. |
-| `.apply to <env>` | Apply the saved plan for the same environment and commit. |
+| `.apply to <env>` | Apply the latest successful saved plan for the same environment and commit. |
 | `.apply main to <env>` | Roll back by applying the stable branch directly. |
 | `.lock <env>` | Lock an environment. |
 | `.unlock <env>` | Release a lock. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -145,7 +145,7 @@ Review the plan comment. If it is correct, apply the saved plan:
 
 If new commits are pushed after planning, run `.plan to dev` again before applying.
 
-Normal apply uses the latest successful saved plan for the same environment and commit. It must not run a fresh untargeted Terraform apply.
+Normal apply uses the latest successful saved plan for the same environment and commit. The restored cache key and saved metadata must agree before Terraform runs. It must not run a fresh untargeted Terraform apply.
 
 After apply completes, the result is posted back to the pull request:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -145,9 +145,7 @@ Review the plan comment. If it is correct, apply the saved plan:
 
 If new commits are pushed after planning, run `.plan to dev` again before applying.
 
-!!! warning "Apply the saved plan"
-
-    Normal apply uses the latest successful saved plan for the same environment and commit. It must not run a fresh untargeted Terraform apply.
+Normal apply uses the latest successful saved plan for the same environment and commit. It must not run a fresh untargeted Terraform apply.
 
 After apply completes, the result is posted back to the pull request:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,7 +147,7 @@ If new commits are pushed after planning, run `.plan to dev` again before applyi
 
 !!! warning "Apply the saved plan"
 
-    Normal apply uses the saved plan for the same environment and commit. It must not run a fresh untargeted Terraform apply.
+    Normal apply uses the latest successful saved plan for the same environment and commit. It must not run a fresh untargeted Terraform apply.
 
 After apply completes, the result is posted back to the pull request:
 
@@ -166,6 +166,9 @@ The matching apply command stays the same:
 ```
 
 The saved targeted plan is restored and applied. Terraform Branch Deploy rejects extra Terraform arguments on apply.
+
+If you run another successful plan for the same environment and commit, that
+newer plan is the one a later apply uses.
 
 ## 5. Roll Back
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -92,10 +92,11 @@ Common examples:
 - `.plan to dev | -var-file=env/dev.tfvars`: Adds a variable file inside the environment working directory.
 - `.plan to dev | -refresh=false`: Skips refresh for that plan.
 
-Extra arguments from `.plan` are part of the saved plan. A later `.apply to <env>` applies that saved plan without needing to repeat those arguments.
+Extra arguments from `.plan` are part of the saved plan. A later `.apply to <env>` applies that saved plan without needing to repeat those arguments. The restored cache key and saved metadata must agree on the plan argument hash before Terraform runs.
 
 PR comment `-var-file` values must be relative paths inside the environment
-working directory. Absolute paths and `..` traversal are rejected.
+working directory after symlink resolution. Absolute paths and `..` traversal
+are rejected.
 
 !!! warning "Extra arguments are plan-only"
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ The default command set is:
 | Command | Purpose |
 | --- | --- |
 | `.plan to <env>` | Run `terraform plan`, post the result, and save the plan. |
-| `.apply to <env>` | Apply the saved plan for the same environment and commit. |
+| `.apply to <env>` | Apply the latest successful saved plan for the same environment and commit. |
 | `.apply main to <env>` | Roll back by applying the stable branch directly. |
 | `.lock <env>` | Lock one environment. |
 | `.unlock <env>` | Unlock one environment. |
@@ -45,9 +45,11 @@ Plan runs `terraform init` and `terraform plan` for the selected environment. Th
 
 A normal apply requires a saved plan. If new commits are pushed after planning, run `.plan to <env>` again.
 
-Apply restores the saved plan for the environment and commit SHA. It does not create a fresh plan during a normal apply.
+Apply restores the latest successful saved plan for the environment and commit SHA. It does not create a fresh plan during a normal apply.
 
 Saved plan metadata is required and verified before the plan is applied. Re-plan to replace older cached plans that do not have metadata.
+
+If you run multiple successful plans for the same environment and commit, the newest successful plan is the one a later apply uses.
 
 ## Rollback
 
@@ -87,9 +89,13 @@ Common examples:
 
 - `.plan to dev | -target=module.api`: Plans only `module.api`.
 - `.plan to dev | -var='replicas=3'`: Adds a Terraform variable.
+- `.plan to dev | -var-file=env/dev.tfvars`: Adds a variable file inside the environment working directory.
 - `.plan to dev | -refresh=false`: Skips refresh for that plan.
 
 Extra arguments from `.plan` are part of the saved plan. A later `.apply to <env>` applies that saved plan without needing to repeat those arguments.
+
+PR comment `-var-file` values must be relative paths inside the environment
+working directory. Absolute paths and `..` traversal are rejected.
 
 !!! warning "Extra arguments are plan-only"
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -73,7 +73,7 @@ Terraform Branch Deploy handles the Terraform execution path after Branch Deploy
 | Area | Control |
 | --- | --- |
 | Environment scope | Execute mode validates the requested environment against `.tf-branch-deploy.yml`. |
-| Normal apply | `.apply to <env>` requires a saved plan file for the environment and commit SHA. |
+| Normal apply | `.apply to <env>` requires the latest successful saved plan file for the environment and commit SHA. |
 | Cache miss behavior | If the saved plan is not restored, apply fails instead of running an untargeted apply. |
 | Saved plan consistency | New plans include metadata with environment, commit SHA, checksum, Terraform version, extra arguments, params hash, and creation time. |
 | Metadata verification | Apply requires valid metadata. Re-plan to replace older cached plans without metadata. |
@@ -91,7 +91,7 @@ Normal apply should be:
 .apply to prod
 ```
 
-The saved plan is tied to the environment and commit SHA. If new commits are pushed, run the plan again.
+The saved plan is tied to the environment and commit SHA. If new commits are pushed, run the plan again. If you run another successful plan for the same environment and commit, that newer saved plan supersedes the older one.
 
 !!! warning "Do not use apply as a second plan"
 
@@ -105,6 +105,8 @@ Targeted plans follow the same rule:
 ```
 
 The apply restores the saved targeted plan. It does not create a fresh plan.
+
+PR comment `-var-file` values must stay inside the environment working directory. Use relative paths and do not use absolute paths or `..` traversal.
 
 ![Targeted Terraform plan warning in GitHub](assets/images/workflow/06-targeted-plan-warning.png)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -76,11 +76,11 @@ Terraform Branch Deploy handles the Terraform execution path after Branch Deploy
 | Normal apply | `.apply to <env>` requires the latest successful saved plan file for the environment and commit SHA. |
 | Cache miss behavior | If the saved plan is not restored, apply fails instead of running an untargeted apply. |
 | Saved plan consistency | New plans include metadata with environment, commit SHA, checksum, Terraform version, extra arguments, params hash, and creation time. |
-| Metadata verification | Apply requires valid metadata. Re-plan to replace older cached plans without metadata. |
+| Metadata verification | Apply requires valid metadata, a matching cache-key params hash, and a valid checksum. Re-plan to replace older cached plans without metadata. |
 | Targeted plans | Extra plan arguments are captured in the saved plan; apply uses that saved plan. |
 | Rollback | `.apply main to <env>` is a separate stable branch apply path and does not use a PR plan. |
 
-Saved plan files and metadata are restored from GitHub Actions cache. The metadata check helps catch mismatches between the restored plan and the current command context; it is not an independent tamper-proof artifact store.
+Saved plan files and metadata are restored from GitHub Actions cache. The cache key includes the saved plan params hash, and apply refuses a restored plan if the key and metadata disagree. The cache is not an independent tamper-proof artifact store.
 
 ## Plan Before Apply
 
@@ -106,7 +106,7 @@ Targeted plans follow the same rule:
 
 The apply restores the saved targeted plan. It does not create a fresh plan.
 
-PR comment `-var-file` values must stay inside the environment working directory. Use relative paths and do not use absolute paths or `..` traversal.
+PR comment `-var-file` values must stay inside the environment working directory after path and symlink resolution. Use relative paths and do not use absolute paths or `..` traversal.
 
 ![Targeted Terraform plan warning in GitHub](assets/images/workflow/06-targeted-plan-warning.png)
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -82,7 +82,7 @@ Fix:
 .apply to dev
 ```
 
-If new commits were pushed after planning, run the plan again. Plans are tied to the commit SHA.
+If new commits were pushed after planning, run the plan again. Plans are tied to the commit SHA. If you create another successful plan for the same commit and environment, apply uses that newer plan.
 
 ## Targeted Plan Was Not Applied
 
@@ -93,7 +93,7 @@ Use the same simple apply command after a targeted plan:
 .apply to prod
 ```
 
-The apply should restore and apply the saved plan. If it reports no saved plan, re-run `.plan to prod | -target=module.database` and inspect the workflow logs for cache restore messages.
+The apply should restore and apply the latest successful saved plan. If it reports no saved plan, re-run `.plan to prod | -target=module.database` and inspect the workflow logs for cache restore messages.
 
 Do not use rollback to target only part of the previous change. Rollback applies
 the stable branch directly, and Terraform does not provide a deterministic

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -84,6 +84,24 @@ Fix:
 
 If new commits were pushed after planning, run the plan again. Plans are tied to the commit SHA. If you create another successful plan for the same commit and environment, apply uses that newer plan.
 
+## Saved Plan Parameter Mismatch
+
+This means the restored cache entry and saved plan metadata do not describe the same plan arguments.
+
+Fix:
+
+```text
+.plan to dev
+.apply to dev
+```
+
+If you planned with extra arguments, run that plan again and then apply normally:
+
+```text
+.plan to dev | -target=module.database
+.apply to dev
+```
+
 ## Targeted Plan Was Not Applied
 
 Use the same simple apply command after a targeted plan:

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -150,7 +150,7 @@ Normal apply uses the latest successful saved plan for the same environment and 
 .apply to prod
 ```
 
-The apply command restores and applies the saved targeted plan. It does not run a fresh untargeted apply. If you run another successful plan for the same environment and commit, that newer plan supersedes the older one.
+The apply command restores and applies the saved targeted plan. It does not run a fresh untargeted apply. The restored cache key and saved metadata must agree on the plan argument hash. If you run another successful plan for the same environment and commit, that newer plan supersedes the older one.
 
 Rollback remains a direct stable-branch apply:
 

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -143,14 +143,14 @@ Prefer `TF_BD_*` environment variables after trigger mode. If your workflow used
 
 ### Terraform Behavior
 
-Normal apply uses the saved plan for the same environment and commit SHA:
+Normal apply uses the latest successful saved plan for the same environment and commit SHA:
 
 ```text
 .plan to prod | -target=module.database
 .apply to prod
 ```
 
-The apply command restores and applies the saved targeted plan. It does not run a fresh untargeted apply.
+The apply command restores and applies the saved targeted plan. It does not run a fresh untargeted apply. If you run another successful plan for the same environment and commit, that newer plan supersedes the older one.
 
 Rollback remains a direct stable-branch apply:
 

--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
@@ -162,6 +163,7 @@ BLOCKED_EXTRA_ARG_FLAGS: frozenset[str] = frozenset(
 )
 
 VALID_OPERATIONS: frozenset[str] = frozenset({"plan", "apply", "rollback"})
+PLAN_CACHE_KEY_RE = re.compile(r"^(?P<params_hash>no-args|[0-9a-f]{8})-\d+-\d+$")
 
 NON_PLAN_EXTRA_ARGS_ERROR = (
     "Extra Terraform arguments are only supported on plan commands. "
@@ -262,16 +264,39 @@ def _validate_pr_var_file_path(value: str) -> None:
         _fail_arg_validation("Unsupported PR comment -var-file path traversal")
 
 
-def _validate_arg_value(flag: str, value: str, source: str) -> None:
+def _validate_pr_var_file_real_path(value: str, working_dir: Path | None) -> None:
+    """Ensure PR-supplied var files cannot escape through symlinks."""
+    if working_dir is None:
+        return
+
+    try:
+        base = working_dir.resolve(strict=False)
+        resolved = (base / value).resolve(strict=False)
+    except (OSError, RuntimeError):
+        _fail_arg_validation("Unsupported PR comment -var-file path cannot be resolved")
+        raise
+
+    if not resolved.is_relative_to(base):
+        _fail_arg_validation("Unsupported PR comment -var-file path outside working directory")
+
+
+def _validate_arg_value(
+    flag: str,
+    value: str,
+    source: str,
+    working_dir: Path | None,
+) -> None:
     """Validate a Terraform argument value when the flag needs value checks."""
     if source == "PR comment" and flag == "-var-file":
         _validate_pr_var_file_path(value)
+        _validate_pr_var_file_real_path(value, working_dir)
 
 
 def _validate_args_allowed(
     args: list[str],
     allowed_flags: frozenset[str],
     source: str,
+    working_dir: Path | None = None,
 ) -> list[str]:
     """Validate args against an allowlist for a specific source."""
     validated: list[str] = []
@@ -284,10 +309,10 @@ def _validate_args_allowed(
         validated.append(arg)
 
         if _arg_has_inline_value(arg):
-            _validate_arg_value(flag, arg.split("=", 1)[1], source)
+            _validate_arg_value(flag, arg.split("=", 1)[1], source, working_dir)
         else:
             if value := _separate_value_for_arg(args, i, flag, source):
-                _validate_arg_value(flag, value, source)
+                _validate_arg_value(flag, value, source, working_dir)
                 validated.append(value)
                 i += 1
 
@@ -296,13 +321,13 @@ def _validate_args_allowed(
     return validated
 
 
-def _validate_extra_args(args: list[str]) -> list[str]:
+def _validate_extra_args(args: list[str], working_dir: Path | None = None) -> list[str]:
     """Validate parsed extra args against the allowlist.
 
     Raises:
         typer.Exit: If any arg uses a blocked or unknown flag.
     """
-    return _validate_args_allowed(args, ALLOWED_EXTRA_ARG_FLAGS, "PR comment")
+    return _validate_args_allowed(args, ALLOWED_EXTRA_ARG_FLAGS, "PR comment", working_dir)
 
 
 def _validate_config_args(
@@ -314,7 +339,11 @@ def _validate_config_args(
     _validate_args_allowed(apply_args, ALLOWED_APPLY_CONFIG_ARG_FLAGS, "apply-args")
 
 
-def _resolve_extra_plan_args(operation: str, raw_extra_args: str | None) -> list[str]:
+def _resolve_extra_plan_args(
+    operation: str,
+    raw_extra_args: str | None,
+    working_dir: Path | None = None,
+) -> list[str]:
     """Parse and validate PR comment args for plan operations."""
     if operation != "plan" and raw_extra_args and raw_extra_args.strip():
         msg = NON_PLAN_EXTRA_ARGS_ERROR
@@ -325,11 +354,29 @@ def _resolve_extra_plan_args(operation: str, raw_extra_args: str | None) -> list
     if not raw_extra_args:
         return []
 
-    parsed_args = _validate_extra_args(_parse_extra_args(raw_extra_args))
+    parsed_args = _validate_extra_args(_parse_extra_args(raw_extra_args), working_dir)
     console.print(
         f"[cyan]📝 Extra args from command:[/cyan] {_redact_args_for_display(parsed_args)}"
     )
     return parsed_args
+
+
+def _params_hash_from_cache_key(
+    cache_key: str | None,
+    environment: str,
+    sha: str,
+) -> str | None:
+    """Extract the saved plan params hash from an actions/cache key."""
+    if not cache_key:
+        return None
+
+    prefix = f"tfplan-{environment}-{sha}-"
+    if not cache_key.startswith(prefix):
+        return None
+
+    if match := PLAN_CACHE_KEY_RE.match(cache_key.removeprefix(prefix)):
+        return match.group("params_hash")
+    return None
 
 
 def _print_execution_table(
@@ -638,7 +685,11 @@ def execute(
         raise typer.Exit(1)
 
     raw_extra_args = extra_args or os.environ.get("TF_BD_EXTRA_ARGS")
-    parsed_extra_args = _resolve_extra_plan_args(operation, raw_extra_args)
+    parsed_extra_args = _resolve_extra_plan_args(
+        operation,
+        raw_extra_args,
+        resolved_working_dir,
+    )
     _print_execution_table(
         environment, operation, sha, resolved_working_dir, dry_run, parsed_extra_args
     )
@@ -802,7 +853,18 @@ def _handle_apply(
             raise typer.Exit(1)
         console.print("[dim]📋 Rollback applied directly (no plan file)[/dim]")
     elif plan_file.exists():
-        _apply_with_plan(executor, plan_file, environment, sha)
+        expected_params_hash = _params_hash_from_cache_key(
+            os.environ.get("TF_BD_PLAN_CACHE_KEY"),
+            environment,
+            sha,
+        )
+        _apply_with_plan(
+            executor,
+            plan_file,
+            environment,
+            sha,
+            expected_params_hash=expected_params_hash,
+        )
         console.print(f"[dim]📋 Plan applied: {plan_filename}[/dim]")
     else:
         console.print(f"[red]❌ No plan file found for this SHA: {plan_file}[/red]")
@@ -826,6 +888,7 @@ def _apply_with_plan(
     plan_file: Path,
     environment: str,
     sha: str,
+    expected_params_hash: str | None = None,
 ) -> None:
     """Apply using an existing plan file with integrity verification.
 
@@ -864,6 +927,29 @@ def _apply_with_plan(
             message=(
                 f"Saved plan commit mismatch: plan was created for `{metadata.sha[:8]}`, "
                 f"but apply requested `{sha[:8]}`."
+            ),
+            suggestion=f"Create a fresh plan by running `.plan to {environment}`",
+        )
+        set_github_output("failure_reason", error_msg)
+        raise typer.Exit(1)
+
+    if expected_params_hash is None:
+        error_msg = format_error_for_comment(
+            message=(
+                "Saved plan cache identity was not found. Terraform Branch Deploy "
+                "cannot verify which plan parameters were restored."
+            ),
+            suggestion=f"Create a fresh plan by running `.plan to {environment}`",
+        )
+        set_github_output("failure_reason", error_msg)
+        raise typer.Exit(1)
+
+    if metadata.params_hash != expected_params_hash:
+        error_msg = format_error_for_comment(
+            message=(
+                "Saved plan parameter mismatch: the restored cache key identifies "
+                f"params hash `{expected_params_hash}`, but the plan metadata records "
+                f"`{metadata.params_hash}`."
             ),
             suggestion=f"Create a fresh plan by running `.plan to {environment}`",
         )

--- a/src/tf_branch_deploy/cli.py
+++ b/src/tf_branch_deploy/cli.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum
 from importlib.metadata import PackageNotFoundError, version
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Annotated
 
 if TYPE_CHECKING:
@@ -246,6 +246,28 @@ def _separate_value_for_arg(
     return None
 
 
+def _validate_pr_var_file_path(value: str) -> None:
+    """Restrict PR-supplied var files to paths inside the Terraform root."""
+    path = value.strip()
+    if not path:
+        _fail_arg_validation("Missing value for PR comment arg: -var-file")
+
+    if path == "~" or path.startswith("~/") or path.startswith("~\\"):
+        _fail_arg_validation("Unsupported PR comment -var-file path outside working directory")
+
+    if PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute():
+        _fail_arg_validation("Unsupported PR comment -var-file absolute path")
+
+    if ".." in PurePosixPath(path).parts or ".." in PureWindowsPath(path).parts:
+        _fail_arg_validation("Unsupported PR comment -var-file path traversal")
+
+
+def _validate_arg_value(flag: str, value: str, source: str) -> None:
+    """Validate a Terraform argument value when the flag needs value checks."""
+    if source == "PR comment" and flag == "-var-file":
+        _validate_pr_var_file_path(value)
+
+
 def _validate_args_allowed(
     args: list[str],
     allowed_flags: frozenset[str],
@@ -261,8 +283,11 @@ def _validate_args_allowed(
         _validate_arg_flag(flag, allowed_flags, source)
         validated.append(arg)
 
-        if not _arg_has_inline_value(arg):
+        if _arg_has_inline_value(arg):
+            _validate_arg_value(flag, arg.split("=", 1)[1], source)
+        else:
             if value := _separate_value_for_arg(args, i, flag, source):
+                _validate_arg_value(flag, value, source)
                 validated.append(value)
                 i += 1
 
@@ -892,6 +917,7 @@ def _apply_with_plan(
             "[dim]📝 Plan was created with args: "
             f"{_redact_args_for_display(metadata.extra_args)}[/dim]"
         )
+    console.print(f"[dim]📝 Plan params hash: {metadata.params_hash}[/dim]")
     console.print(f"[dim]📝 Plan created at: {metadata.created_at}[/dim]")
 
     # Pass only the filename to the executor — not the full path.

--- a/tests/contract/test_action_runtime_contract.py
+++ b/tests/contract/test_action_runtime_contract.py
@@ -15,6 +15,13 @@ def action() -> dict[str, Any]:
         return yaml.safe_load(f)
 
 
+@pytest.fixture
+def action_text() -> str:
+    """Load action.yml as text so comments remain testable."""
+    action_path = Path(__file__).parent.parent.parent / "action.yml"
+    return action_path.read_text(encoding="utf-8")
+
+
 def step_by_name(action: dict[str, Any], name: str) -> dict[str, Any]:
     """Return an action step by name."""
     for step in action["runs"]["steps"]:
@@ -192,12 +199,13 @@ class TestCompositeRuntimeContract:
         assert 'export PATH="${TFBD_TOOL_DIR}:${PATH}"' in execute_step["run"]
 
     def test_execute_mode_cache_restore_and_save_are_environment_and_sha_scoped(
-        self, action: dict[str, Any]
+        self, action: dict[str, Any], action_text: str
     ) -> None:
         """A plan from another environment or SHA must not be restored."""
         restore_step = step_by_name(action, "[Execute] Restore Cached Plan")
         save_step = step_by_name(action, "[Execute] Cache Plan File")
 
+        assert "latest successful plan" in action_text
         assert restore_step["uses"].startswith("actions/cache/restore@")
         assert restore_step["if"] == "inputs.mode == 'execute' && env.TF_BD_OPERATION == 'apply'"
         restore_paths = restore_step["with"]["path"].splitlines()

--- a/tests/contract/test_action_runtime_contract.py
+++ b/tests/contract/test_action_runtime_contract.py
@@ -201,11 +201,14 @@ class TestCompositeRuntimeContract:
     def test_execute_mode_cache_restore_and_save_are_environment_and_sha_scoped(
         self, action: dict[str, Any], action_text: str
     ) -> None:
-        """A plan from another environment or SHA must not be restored."""
+        """A plan from another environment, SHA, or params hash must not be restored."""
         restore_step = step_by_name(action, "[Execute] Restore Cached Plan")
         save_step = step_by_name(action, "[Execute] Cache Plan File")
+        execute_step = step_by_id(action, "tf-execute")
 
         assert "latest successful plan" in action_text
+        assert "params hash" in action_text
+        assert restore_step["id"] == "restore-plan"
         assert restore_step["uses"].startswith("actions/cache/restore@")
         assert restore_step["if"] == "inputs.mode == 'execute' && env.TF_BD_OPERATION == 'apply'"
         restore_paths = restore_step["with"]["path"].splitlines()
@@ -213,18 +216,28 @@ class TestCompositeRuntimeContract:
         assert "**/tfplan-${{ env.TF_BD_ENVIRONMENT }}-*.meta.json" in restore_paths
         assert (
             restore_step["with"]["key"]
-            == "tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-${{ github.run_id }}-${{ github.run_attempt }}"
+            == "tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-no-args-${{ github.run_id }}-${{ github.run_attempt }}"
         )
         assert (
             "tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-"
             in restore_step["with"]["restore-keys"]
         )
+        assert (
+            execute_step["env"]["TF_BD_PLAN_CACHE_KEY"]
+            == "${{ steps.restore-plan.outputs.cache-matched-key }}"
+        )
 
-        assert save_step["uses"].startswith("actions/cache@")
-        assert save_step["if"] == "inputs.mode == 'execute' && env.TF_BD_OPERATION == 'plan'"
+        assert save_step["uses"].startswith("actions/cache/save@")
+        assert (
+            save_step["if"]
+            == "inputs.mode == 'execute' && env.TF_BD_OPERATION == 'plan' && steps.tf-execute.outputs.plan_params_hash != ''"
+        )
         save_paths = save_step["with"]["path"].splitlines()
         assert save_paths == restore_paths
-        assert save_step["with"]["key"] == restore_step["with"]["key"]
+        assert (
+            save_step["with"]["key"]
+            == "tfplan-${{ env.TF_BD_ENVIRONMENT }}-${{ env.TF_BD_SHA }}-${{ steps.tf-execute.outputs.plan_params_hash }}-${{ github.run_id }}-${{ github.run_attempt }}"
+        )
 
     def test_lifecycle_completion_runs_on_success_and_failure_with_ghe_context(
         self, action: dict[str, Any]

--- a/tests/contract/test_docs_contract.py
+++ b/tests/contract/test_docs_contract.py
@@ -119,9 +119,10 @@ def test_changelog_is_public_release_history() -> None:
     assert "## [0.1.0]" in changelog
     for phrase in [
         "conversation",
-        "agent",
         "200%",
+        "ai agent",
         "ai-generated",
+        "autonomous agent",
         "we haven't",
         "for now",
         "future work",

--- a/tests/contract/test_docs_contract.py
+++ b/tests/contract/test_docs_contract.py
@@ -104,3 +104,27 @@ def test_release_docs_match_action_ref_policy() -> None:
     assert "scarowar/terraform-branch-deploy@<terraform-branch-deploy-ref>" in release
     assert "docs/includes/version.txt" not in release
     assert "scripts/update-version.sh" not in release
+
+
+def test_changelog_is_public_release_history() -> None:
+    """The changelog should stay factual and user-facing."""
+    changelog_path = ROOT / "CHANGELOG.md"
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    changelog = changelog_path.read_text(encoding="utf-8")
+    lowered = changelog.lower()
+
+    assert changelog_path.exists()
+    assert "[Changelog](CHANGELOG.md)" in readme
+    assert "## [0.2.0]" in changelog
+    assert "## [0.1.0]" in changelog
+    for phrase in [
+        "conversation",
+        "agent",
+        "200%",
+        "ai-generated",
+        "we haven't",
+        "for now",
+        "future work",
+        "deferred",
+    ]:
+        assert phrase not in lowered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,10 +14,11 @@ from tf_branch_deploy.cli import (
     BLOCKED_EXTRA_ARG_FLAGS,
     DEFAULT_CONFIG_PATH,
     _ArgTokenizer,
-    _handle_plan,
     _apply_with_plan,
     _handle_apply,
+    _handle_plan,
     _load_and_validate_config,
+    _params_hash_from_cache_key,
     _parse_extra_args,
     _strip_shell_quotes,
     _validate_config_args,
@@ -154,6 +155,51 @@ class TestValidateExtraArgs:
         args = ["-var-file=env/dev.tfvars", "-var-file", "./shared.tfvars"]
         assert _validate_extra_args(args) == args
 
+    def test_var_file_missing_relative_path_inside_working_dir_allowed(
+        self, tmp_path: Path
+    ) -> None:
+        """A repo-local var file path does not have to exist before Terraform reads it."""
+        working_dir = tmp_path / "terraform"
+        working_dir.mkdir()
+
+        args = ["-var-file=env/dev.tfvars"]
+
+        assert _validate_extra_args(args, working_dir) == args
+
+    def test_var_file_symlink_directory_escape_blocked(self, tmp_path: Path) -> None:
+        """PR comment -var-file must not escape through a symlinked directory."""
+        working_dir = tmp_path / "terraform"
+        outside_dir = tmp_path / "outside"
+        working_dir.mkdir()
+        outside_dir.mkdir()
+
+        symlink_dir = working_dir / "linked"
+        try:
+            symlink_dir.symlink_to(outside_dir, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks are not supported on this filesystem")
+
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-var-file=linked/secret.tfvars"], working_dir)
+
+    def test_var_file_symlink_file_escape_blocked(self, tmp_path: Path) -> None:
+        """PR comment -var-file must not escape through a symlinked file."""
+        working_dir = tmp_path / "terraform"
+        outside_dir = tmp_path / "outside"
+        working_dir.mkdir()
+        outside_dir.mkdir()
+        outside_file = outside_dir / "secret.tfvars"
+        outside_file.write_text('token = "secret"\n', encoding="utf-8")
+
+        symlink_file = working_dir / "secret.tfvars"
+        try:
+            symlink_file.symlink_to(outside_file)
+        except OSError:
+            pytest.skip("symlinks are not supported on this filesystem")
+
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-var-file=secret.tfvars"], working_dir)
+
     @pytest.mark.parametrize(
         "arg",
         [
@@ -263,6 +309,30 @@ class TestValidateConfigArgs:
 
     def test_apply_args_accept_split_var(self) -> None:
         _validate_config_args([], ["-var", "key=value"])
+
+
+class TestPlanCacheKey:
+    """Tests for extracting saved plan identity from actions/cache keys."""
+
+    @pytest.mark.parametrize("params_hash", ["no-args", "a1b2c3d4"])
+    def test_extracts_params_hash_from_valid_key(self, params_hash: str) -> None:
+        cache_key = f"tfplan-int-abc12345ff-{params_hash}-123456789-1"
+
+        assert _params_hash_from_cache_key(cache_key, "int", "abc12345ff") == params_hash
+
+    @pytest.mark.parametrize(
+        "cache_key",
+        [
+            None,
+            "",
+            "tfplan-prod-abc12345ff-no-args-123456789-1",
+            "tfplan-int-different-no-args-123456789-1",
+            "tfplan-int-abc12345ff-123456789-1",
+            "tfplan-int-abc12345ff-not-a-hash-123456789-1",
+        ],
+    )
+    def test_returns_none_for_missing_or_untrusted_key(self, cache_key: str | None) -> None:
+        assert _params_hash_from_cache_key(cache_key, "int", "abc12345ff") is None
 
 
 class TestStripShellQuotes:
@@ -669,6 +739,7 @@ class TestHandleApply:
 
         env_vars = {
             "TF_BD_IS_ROLLBACK": "false",
+            "TF_BD_PLAN_CACHE_KEY": "tfplan-int-abc12345ff-no-args-123-1",
         }
 
         with patch.dict("os.environ", env_vars):
@@ -703,7 +774,13 @@ class TestHandleApply:
         mock_executor.version.return_value = "1.9.8"
 
         with patch.dict("os.environ", {}, clear=False):
-            _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+            _apply_with_plan(
+                mock_executor,
+                plan_file,
+                "int",
+                "abc12345ff",
+                expected_params_hash="no-args",
+            )
 
         call_args = mock_executor.apply.call_args
         plan_arg = call_args.kwargs.get("plan_file")
@@ -733,7 +810,10 @@ class TestHandleApply:
         mock_executor.working_directory = working_dir
         mock_executor.version.return_value = "1.9.8"
 
-        env_vars = {"TF_BD_IS_ROLLBACK": "false"}
+        env_vars = {
+            "TF_BD_IS_ROLLBACK": "false",
+            "TF_BD_PLAN_CACHE_KEY": "tfplan-int-abc12345ff-no-args-123-1",
+        }
 
         with patch.dict("os.environ", env_vars):
             _handle_apply(mock_executor, "int", "abc12345ff", working_dir)
@@ -744,6 +824,31 @@ class TestHandleApply:
         assert str(plan_arg) == "tfplan-int-abc12345.tfplan"
         # Verify it does NOT contain the working_dir prefix
         assert "terraform/modules" not in str(plan_arg)
+
+    def test_handle_apply_rejects_cache_metadata_params_mismatch(self, tmp_path: Path) -> None:
+        """Apply refuses a restored plan when cache key and metadata disagree."""
+        from click.exceptions import Exit as ClickExit
+        from unittest.mock import MagicMock, patch
+
+        working_dir = tmp_path / "terraform"
+        working_dir.mkdir()
+
+        plan_file = working_dir / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan")
+        _save_plan_metadata(plan_file, params_hash="a1b2c3d4")
+
+        mock_executor = MagicMock()
+
+        env_vars = {
+            "TF_BD_IS_ROLLBACK": "false",
+            "TF_BD_PLAN_CACHE_KEY": "tfplan-int-abc12345ff-deadbeef-123-1",
+        }
+
+        with patch.dict("os.environ", env_vars):
+            with pytest.raises(ClickExit):
+                _handle_apply(mock_executor, "int", "abc12345ff", working_dir)
+
+        mock_executor.apply.assert_not_called()
 
     def test_apply_rejects_extra_args(self, tmp_path: Path) -> None:
         """Normal apply must not accept fresh Terraform args from comments."""
@@ -817,7 +922,13 @@ class TestApplyWithPlanIntegrity:
         mock_executor.version.return_value = "1.9.8"
 
         with patch.dict("os.environ", {}, clear=False):
-            _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+            _apply_with_plan(
+                mock_executor,
+                plan_file,
+                "int",
+                "abc12345ff",
+                expected_params_hash="no-args",
+            )
 
         # apply() must be called with just the filename (executor resolves from working_dir)
         mock_executor.apply.assert_called_once_with(plan_file=Path(plan_file.name))
@@ -844,12 +955,60 @@ class TestApplyWithPlanIntegrity:
         mock_executor.version.return_value = "1.9.8"
 
         with patch.dict("os.environ", {}, clear=False):
-            _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+            _apply_with_plan(
+                mock_executor,
+                plan_file,
+                "int",
+                "abc12345ff",
+                expected_params_hash="a1b2c3d4",
+            )
 
         output = capsys.readouterr().out
         assert "Plan was created with args:" in output
         assert "-target=module.base" in output
         assert "Plan params hash: a1b2c3d4" in output
+
+    def test_saved_plan_cache_identity_required(self, tmp_path: Path) -> None:
+        """Apply must know which cache key restored the plan before using it."""
+        from unittest.mock import MagicMock, patch
+
+        from click.exceptions import Exit as ClickExit
+
+        plan_file = tmp_path / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan content")
+        _save_plan_metadata(plan_file)
+
+        mock_executor = MagicMock()
+
+        with patch.dict("os.environ", {}, clear=False):
+            with pytest.raises(ClickExit):
+                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+
+        mock_executor.apply.assert_not_called()
+
+    def test_saved_plan_params_hash_mismatch_aborts(self, tmp_path: Path) -> None:
+        """A restored cache entry cannot apply a plan with different PR args."""
+        from unittest.mock import MagicMock, patch
+
+        from click.exceptions import Exit as ClickExit
+
+        plan_file = tmp_path / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan content")
+        _save_plan_metadata(plan_file, params_hash="a1b2c3d4")
+
+        mock_executor = MagicMock()
+
+        with patch.dict("os.environ", {}, clear=False):
+            with pytest.raises(ClickExit):
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="deadbeef",
+                )
+
+        mock_executor.apply.assert_not_called()
 
     def test_checksum_mismatch_aborts(self, tmp_path: Path) -> None:
         """Checksum mismatch from metadata sidecar aborts with exit code 1."""
@@ -870,7 +1029,13 @@ class TestApplyWithPlanIntegrity:
 
         with patch.dict("os.environ", {}, clear=False):
             with pytest.raises(ClickExit):
-                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="no-args",
+                )
 
         # apply() must NOT be called
         mock_executor.apply.assert_not_called()
@@ -890,7 +1055,13 @@ class TestApplyWithPlanIntegrity:
 
         with patch.dict("os.environ", {}, clear=False):
             with pytest.raises(ClickExit):
-                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="no-args",
+                )
 
         mock_executor.apply.assert_not_called()
 
@@ -907,7 +1078,13 @@ class TestApplyWithPlanIntegrity:
 
         with patch.dict("os.environ", {"TF_BD_PLAN_CHECKSUM": "legacy"}, clear=False):
             with pytest.raises(ClickExit):
-                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="no-args",
+                )
 
         mock_executor.apply.assert_not_called()
 
@@ -925,7 +1102,13 @@ class TestApplyWithPlanIntegrity:
 
         with patch.dict("os.environ", {}, clear=False):
             with pytest.raises(ClickExit):
-                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="no-args",
+                )
 
         mock_executor.apply.assert_not_called()
 
@@ -943,7 +1126,13 @@ class TestApplyWithPlanIntegrity:
 
         with patch.dict("os.environ", {}, clear=False):
             with pytest.raises(ClickExit):
-                _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+                _apply_with_plan(
+                    mock_executor,
+                    plan_file,
+                    "int",
+                    "abc12345ff",
+                    expected_params_hash="no-args",
+                )
 
         mock_executor.apply.assert_not_called()
 
@@ -960,7 +1149,13 @@ class TestApplyWithPlanIntegrity:
         mock_executor.version.return_value = "1.9.8"
 
         with patch.dict("os.environ", {}, clear=False):
-            _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+            _apply_with_plan(
+                mock_executor,
+                plan_file,
+                "int",
+                "abc12345ff",
+                expected_params_hash="no-args",
+            )
 
         # Should proceed despite version mismatch (unknown is ignored)
         mock_executor.apply.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ def _save_plan_metadata(
     var_files: list[str] | None = None,
     terraform_version: str = "1.9.8",
     checksum: str | None = None,
+    params_hash: str = "no-args",
 ) -> None:
     """Create valid v0.2 plan metadata for apply tests."""
     from tf_branch_deploy.artifacts import PlanMetadata, calculate_checksum, save_plan_metadata
@@ -53,7 +54,7 @@ def _save_plan_metadata(
             plan_args=plan_args or [],
             var_files=var_files or [],
             terraform_version=terraform_version,
-            params_hash="no-args",
+            params_hash=params_hash,
             created_at="2025-01-15T10:00:00+00:00",
         ),
     )
@@ -148,6 +149,34 @@ class TestValidateExtraArgs:
         args = ["-var=key=value"]
         assert _validate_extra_args(args) == args
 
+    def test_var_file_relative_path_allowed(self) -> None:
+        """PR comment -var-file accepts relative paths inside the Terraform root."""
+        args = ["-var-file=env/dev.tfvars", "-var-file", "./shared.tfvars"]
+        assert _validate_extra_args(args) == args
+
+    @pytest.mark.parametrize(
+        "arg",
+        [
+            "-var-file=/etc/passwd",
+            r"-var-file=C:\secret.tfvars",
+            r"-var-file=\\server\share\secret.tfvars",
+            "-var-file=../secret.tfvars",
+            "-var-file=env/../../secret.tfvars",
+            "-var-file=~/secret.tfvars",
+            "-var-file=",
+        ],
+    )
+    def test_var_file_unsafe_paths_blocked(self, arg: str) -> None:
+        """PR comment -var-file must not read outside the working directory."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args([arg])
+
+    @pytest.mark.parametrize("path", ["/etc/passwd", "../secret.tfvars", "env\\..\\secret.tfvars"])
+    def test_var_file_unsafe_split_paths_blocked(self, path: str) -> None:
+        """Split -var-file values get the same path validation as inline values."""
+        with pytest.raises(typer.Exit):
+            _validate_extra_args(["-var-file", path])
+
     def test_split_value_flags_allowed(self) -> None:
         """Common Terraform flag value forms should match Terraform CLI behavior."""
         args = ["-var", "key=value", "-target", "module.database"]
@@ -227,6 +256,10 @@ class TestValidateConfigArgs:
     def test_apply_args_reject_replace(self) -> None:
         with pytest.raises(typer.Exit):
             _validate_config_args([], ["-replace=aws_instance.app"])
+
+    def test_config_args_do_not_use_pr_var_file_path_policy(self) -> None:
+        """Trusted repo config may still use shared var files outside an env dir."""
+        _validate_config_args(["-var-file=../shared/common.tfvars"], [])
 
     def test_apply_args_accept_split_var(self) -> None:
         _validate_config_args([], ["-var", "key=value"])
@@ -788,6 +821,35 @@ class TestApplyWithPlanIntegrity:
 
         # apply() must be called with just the filename (executor resolves from working_dir)
         mock_executor.apply.assert_called_once_with(plan_file=Path(plan_file.name))
+
+    def test_apply_surfaces_saved_plan_args_and_hash(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Apply should show the saved plan identity before using it."""
+        from unittest.mock import MagicMock, patch
+
+        plan_file = tmp_path / "tfplan-int-abc12345.tfplan"
+        plan_file.write_bytes(b"valid plan content")
+        _save_plan_metadata(
+            plan_file,
+            extra_args=["-target=module.base"],
+            plan_args=["-target=module.base"],
+            params_hash="a1b2c3d4",
+        )
+
+        mock_executor = MagicMock()
+        mock_executor.apply.return_value = MagicMock(success=True)
+        mock_executor.version.return_value = "1.9.8"
+
+        with patch.dict("os.environ", {}, clear=False):
+            _apply_with_plan(mock_executor, plan_file, "int", "abc12345ff")
+
+        output = capsys.readouterr().out
+        assert "Plan was created with args:" in output
+        assert "-target=module.base" in output
+        assert "Plan params hash: a1b2c3d4" in output
 
     def test_checksum_mismatch_aborts(self, tmp_path: Path) -> None:
         """Checksum mismatch from metadata sidecar aborts with exit code 1."""


### PR DESCRIPTION
## Summary

- Restrict PR comment `-var-file` values to safe relative paths inside the environment working directory, including symlink resolution.
- Enforce saved-plan identity on apply: the restored cache key params hash must match the saved plan metadata params hash.
- Clarify the saved-plan contract in user-facing docs and add a root changelog for versioned release history.

## Validation

- `uv run pytest` (`243 passed`)
- `uv run pre-commit run --all-files`
- `uv run zensical build --strict --clean`

Closes #150
Closes #151
Closes #152
Closes #154
Closes #155
